### PR TITLE
[feature] Extended options & resolve loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ### Description
 
-This plugin will integrate Webpack module resolution for packages installed
-using `pnpm`.
+This plugin will integrate Webpack module & loader resolution for packages installed
+via `pnpm`.
 
-When using `pnpm`, building a gatsby project will fail because `pnpm` uses a unique
+When using `pnpm`, building a Gatsby project will fail because `pnpm` uses a unique
 `node_modules` structure, and `webpack` doesn't know how to resolve packages in it.
 This plugin will configure `webpack` so that it is able to see `Gatsby`'s dependencies.
 
@@ -36,14 +36,14 @@ That's it.  You should be able to build now.
 project's dependencies, and due to the way Webpack resolves modules (and sometimes because of
 the way those modules are written), it won't be able to.  If this is the case, we need to point
 Webpack the way to where those sub-dependencies are located.  To do that, please include your
-dependency in question in the `resolutions` plugin option described below.
+dependency in question in the `include` plugin option described below.
 
   * Note: the package you define in this manner **MUST** be one of your project's direct
   dependencies.  It will be resolved using your project's `node_modules` directory.
 
 * There are also times where you want Webpack to be able to resolve modules in a directory that
 is not a part of any of your dependency's `node_modules`.  If that's the case, please include
-the directory path in the `resolutions` option described below.
+the directory path in the `include` option described below.
   * If you include a relative path, it will be resolved relative to your `process.cwd()`.
   * **MUST BE A DIRECTORY**.
 
@@ -51,9 +51,9 @@ the directory path in the `resolutions` option described below.
 
 ### Available Options
 
-| Option    | Description |
-|:----------|:------------|
-| resolutions  | A list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.
+| Option   | Description |
+|:---------|:------------|
+| include  | A list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.
 
 Please define plugin options as follows:
 
@@ -65,9 +65,9 @@ module.exports = {
     {
       resolve: `gatsby-plugin-pnpm`,
       options: {
-        resolutions: [
+        include: [
           `my-awesome-package`,
-          `my/private/webpack/loaders`
+          `path/to/my/private/webpack/loaders`
         ]
       }
     }
@@ -78,4 +78,4 @@ module.exports = {
 ## Issues / Contributing
 
 If you notice any issues caused by this plugin, or there seems to be some feature missing,
-please feel free to file an issue at <https://github.com/Js-Brecht/gatsby-plugin-pnpm/issues>.
+please feel free to file an issue at <https://github.com/Js-Brecht/gatsby-plugin-pnpm/issues>

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ module.exports = {
       options: {
         resolutions: [
           `my-awesome-package`,
+          `my/private/webpack/loaders`
         ]
       }
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Description
 
-This plugin will integrate module resolution for packages installed
+This plugin will integrate Webpack module resolution for packages installed
 using `pnpm`.
 
 When using `pnpm`, building a gatsby project will fail because `pnpm` uses a unique
@@ -36,14 +36,14 @@ That's it.  You should be able to build now.
 project's dependencies, and due to the way Webpack resolves modules (and sometimes because of
 the way those modules are written), it won't be able to.  If this is the case, we need to point
 Webpack the way to where those sub-dependencies are located.  To do that, please include your
-dependency in question in the `packages` plugin option described below.
+dependency in question in the `resolutions` plugin option described below.
 
   * Note: the package you define in this manner **MUST** be one of your project's direct
   dependencies.  It will be resolved using your project's `node_modules` directory.
 
 * There are also times where you want Webpack to be able to resolve modules in a directory that
 is not a part of any of your dependency's `node_modules`.  If that's the case, please include
-the directory path in the `packages` option described below.
+the directory path in the `resolutions` option described below.
   * If you include a relative path, it will be resolved relative to your `process.cwd()`.
   * **MUST BE A DIRECTORY**.
 
@@ -53,7 +53,7 @@ the directory path in the `packages` option described below.
 
 | Option    | Description |
 |:----------|:------------|
-| packages  | A list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.
+| resolutions  | A list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.
 
 Please define plugin options as follows:
 
@@ -65,7 +65,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-pnpm`,
       options: {
-        packages: [
+        resolutions: [
           `my-awesome-package`,
         ]
       }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PNPM Compatibility Plugin for Gatsby
+## PNPM Compatibility Plugin for Gatsby
 
-## Description
+### Description
 
 This plugin will integrate module resolution for packages installed
 using `pnpm`.
@@ -11,7 +11,7 @@ This plugin will configure `webpack` so that it is able to see `Gatsby`'s depend
 
 ---
 
-## How to install
+### How to install
 
 * Include the plugin in your `gatsby-config.js`.
 
@@ -27,6 +27,52 @@ module.exports = {
 ```
 
 That's it.  You should be able to build now.
+
+---
+
+### Extended usage
+
+* Sometimes, Webpack may need to resolve a module that is a sub-dependency of one of your
+project's dependencies, and due to the way Webpack resolves modules (and sometimes because of
+the way those modules are written), it won't be able to.  If this is the case, we need to point
+Webpack the way to where those sub-dependencies are located.  To do that, please include your
+dependency in question in the `packages` plugin option described below.
+
+  * Note: the package you define in this manner **MUST** be one of your project's direct
+  dependencies.  It will be resolved using your project's `node_modules` directory.
+
+* There are also times where you want Webpack to be able to resolve modules in a directory that
+is not a part of any of your dependency's `node_modules`.  If that's the case, please include
+the directory path in the `packages` option described below.
+  * If you include a relative path, it will be resolved relative to your `process.cwd()`.
+  * **MUST BE A DIRECTORY**.
+
+---
+
+### Available Options
+
+| Option    | Description |
+|:----------|:------------|
+| packages  | A list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.
+
+Please define plugin options as follows:
+
+```js
+// gatsby-config.js
+module.exports = {
+  plugins: [
+    ...,
+    {
+      resolve: `gatsby-plugin-pnpm`,
+      options: {
+        packages: [
+          `my-awesome-package`,
+        ]
+      }
+    }
+  ]
+}
+```
 
 ## Issues / Contributing
 

--- a/package.json
+++ b/package.json
@@ -38,16 +38,17 @@
     "gatsby": "~2.x.x"
   },
   "devDependencies": {
-    "@jtechsvcs/eslint-config-typescript": "^2.0.1",
-    "@types/node": "^12.6.9",
-    "@typescript-eslint/eslint-plugin": "^2.16.0",
-    "@typescript-eslint/parser": "^2.16.0",
-    "@typescript-eslint/typescript-estree": "^2.16.0",
+    "@jtechsvcs/eslint-config-typescript": "^2.0.3",
+    "@types/node": "^12.12.26",
+    "@types/webpack": "^4.41.5",
+    "@typescript-eslint/eslint-plugin": "^2.19.0",
+    "@typescript-eslint/parser": "^2.19.0",
+    "@typescript-eslint/typescript-estree": "^2.19.0",
     "eslint": "^6.8.0",
-    "gatsby": "^2.13.50",
+    "gatsby": "^2.19.12",
     "npm-run-all": "^4.1.5",
-    "rimraf": "^3.0.0",
-    "typedoc": "^0.15.0",
+    "rimraf": "^3.0.1",
+    "typedoc": "^0.15.8",
     "typescript": "^3.7.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-pnpm",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Easily add pnpm support to your Gatsby project",
   "main": "index.js",
   "types": "./dist/gatsby-node.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,13 +1,14 @@
 devDependencies:
-  '@jtechsvcs/eslint-config-typescript': 2.0.1_0ed20ba8bdc1aaaf6c2385c42cfe57ae
-  '@types/node': 12.12.25
-  '@typescript-eslint/eslint-plugin': 2.16.0_06dd01ff8bc3edf7e85377823fd48c83
-  '@typescript-eslint/parser': 2.16.0_eslint@6.8.0+typescript@3.7.5
-  '@typescript-eslint/typescript-estree': 2.16.0_typescript@3.7.5
+  '@jtechsvcs/eslint-config-typescript': 2.0.3_0e623a8db94d98d9fac7066b18561e21
+  '@types/node': 12.12.26
+  '@types/webpack': 4.41.5
+  '@typescript-eslint/eslint-plugin': 2.19.0_25db45452788e415134bad7c0cac009a
+  '@typescript-eslint/parser': 2.19.0_eslint@6.8.0+typescript@3.7.5
+  '@typescript-eslint/typescript-estree': 2.19.0_typescript@3.7.5
   eslint: 6.8.0
-  gatsby: 2.18.25_gatsby@2.18.25+typescript@3.7.5
+  gatsby: 2.19.12_gatsby@2.19.12+typescript@3.7.5
   npm-run-all: 4.1.5
-  rimraf: 3.0.0
+  rimraf: 3.0.1
   typedoc: 0.15.8
   typescript: 3.7.5
 lockfileVersion: 5.1
@@ -18,37 +19,37 @@ packages:
     dev: true
     resolution:
       integrity: sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
-  /@babel/compat-data/7.8.1:
+  /@babel/compat-data/7.8.5:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       invariant: 2.2.4
       semver: 5.7.1
     dev: true
     resolution:
-      integrity: sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==
-  /@babel/core/7.8.3:
+      integrity: sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==
+  /@babel/core/7.8.4:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/generator': 7.8.3
-      '@babel/helpers': 7.8.3
-      '@babel/parser': 7.8.3
+      '@babel/generator': 7.8.4
+      '@babel/helpers': 7.8.4
+      '@babel/parser': 7.8.4
       '@babel/template': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
       convert-source-map: 1.7.0
       debug: 4.1.1
       gensync: 1.0.0-beta.1
       json5: 2.1.1
       lodash: 4.17.15
-      resolve: 1.14.2
+      resolve: 1.15.0
       semver: 5.7.1
       source-map: 0.5.7
     dev: true
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==
-  /@babel/generator/7.8.3:
+      integrity: sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==
+  /@babel/generator/7.8.4:
     dependencies:
       '@babel/types': 7.8.3
       jsesc: 2.5.2
@@ -56,7 +57,7 @@ packages:
       source-map: 0.5.7
     dev: true
     resolution:
-      integrity: sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==
+      integrity: sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==
   /@babel/helper-annotate-as-pure/7.8.3:
     dependencies:
       '@babel/types': 7.8.3
@@ -80,27 +81,27 @@ packages:
   /@babel/helper-call-delegate/7.8.3:
     dependencies:
       '@babel/helper-hoist-variables': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
     dev: true
     resolution:
       integrity: sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==
-  /@babel/helper-compilation-targets/7.8.3_@babel+core@7.8.3:
+  /@babel/helper-compilation-targets/7.8.4_@babel+core@7.8.4:
     dependencies:
-      '@babel/compat-data': 7.8.1
-      '@babel/core': 7.8.3
-      browserslist: 4.8.3
+      '@babel/compat-data': 7.8.5
+      '@babel/core': 7.8.4
+      browserslist: 4.8.6
       invariant: 2.2.4
-      levenary: 1.1.0
+      levenary: 1.1.1
       semver: 5.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==
-  /@babel/helper-create-class-features-plugin/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==
+  /@babel/helper-create-class-features-plugin/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-function-name': 7.8.3
       '@babel/helper-member-expression-to-functions': 7.8.3
       '@babel/helper-optimise-call-expression': 7.8.3
@@ -112,9 +113,9 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==
-  /@babel/helper-create-regexp-features-plugin/7.8.3_@babel+core@7.8.3:
+  /@babel/helper-create-regexp-features-plugin/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-regex': 7.8.3
       regexpu-core: 4.6.0
     dev: true
@@ -132,7 +133,7 @@ packages:
       integrity: sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==
   /@babel/helper-explode-assignable-expression/7.8.3:
     dependencies:
-      '@babel/traverse': 7.8.3
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
     dev: true
     resolution:
@@ -201,7 +202,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-wrap-function': 7.8.3
       '@babel/template': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
     dev: true
     resolution:
@@ -210,7 +211,7 @@ packages:
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.8.3
       '@babel/helper-optimise-call-expression': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
     dev: true
     resolution:
@@ -232,19 +233,19 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.8.3
       '@babel/template': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
     dev: true
     resolution:
       integrity: sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==
-  /@babel/helpers/7.8.3:
+  /@babel/helpers/7.8.4:
     dependencies:
       '@babel/template': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
     dev: true
     resolution:
-      integrity: sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==
+      integrity: sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==
   /@babel/highlight/7.8.3:
     dependencies:
       chalk: 2.4.2
@@ -253,98 +254,98 @@ packages:
     dev: true
     resolution:
       integrity: sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==
-  /@babel/parser/7.8.3:
+  /@babel/parser/7.8.4:
     dev: true
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==
-  /@babel/plugin-proposal-async-generator-functions/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
+  /@babel/plugin-proposal-async-generator-functions/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-remap-async-to-generator': 7.8.3
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.3
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==
-  /@babel/plugin-proposal-class-properties/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-class-properties/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-class-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.8.4
+      '@babel/helper-create-class-features-plugin': 7.8.3_@babel+core@7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==
-  /@babel/plugin-proposal-dynamic-import/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-dynamic-import/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==
-  /@babel/plugin-proposal-json-strings/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-json-strings/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
-  /@babel/plugin-proposal-object-rest-spread/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-object-rest-spread/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==
-  /@babel/plugin-proposal-optional-catch-binding/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-optional-catch-binding/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==
-  /@babel/plugin-proposal-optional-chaining/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-optional-chaining/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==
-  /@babel/plugin-proposal-unicode-property-regex/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-proposal-unicode-property-regex/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.8.4
+      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     engines:
@@ -353,99 +354,99 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.3:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-jsx/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-jsx/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-top-level-await/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-syntax-top-level-await/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==
-  /@babel/plugin-transform-arrow-functions/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-arrow-functions/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==
-  /@babel/plugin-transform-async-to-generator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-async-to-generator/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-remap-async-to-generator': 7.8.3
@@ -454,18 +455,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==
-  /@babel/plugin-transform-block-scoped-functions/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-block-scoped-functions/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==
-  /@babel/plugin-transform-block-scoping/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-block-scoping/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       lodash: 4.17.15
     dev: true
@@ -473,9 +474,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==
-  /@babel/plugin-transform-classes/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-classes/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-define-map': 7.8.3
       '@babel/helper-function-name': 7.8.3
@@ -489,46 +490,46 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==
-  /@babel/plugin-transform-computed-properties/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-computed-properties/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==
-  /@babel/plugin-transform-destructuring/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-destructuring/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==
-  /@babel/plugin-transform-dotall-regex/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-dotall-regex/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.8.4
+      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==
-  /@babel/plugin-transform-duplicate-keys/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-duplicate-keys/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==
-  /@babel/plugin-transform-exponentiation-operator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-exponentiation-operator/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
@@ -536,18 +537,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==
-  /@babel/plugin-transform-for-of/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-for-of/7.8.4_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==
-  /@babel/plugin-transform-function-name/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==
+  /@babel/plugin-transform-function-name/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-function-name': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
@@ -555,27 +556,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==
-  /@babel/plugin-transform-literals/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-literals/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==
-  /@babel/plugin-transform-member-expression-literals/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-member-expression-literals/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==
-  /@babel/plugin-transform-modules-amd/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-modules-amd/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-module-transforms': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
       babel-plugin-dynamic-import-node: 2.3.0
@@ -584,9 +585,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==
-  /@babel/plugin-transform-modules-commonjs/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-modules-commonjs/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-module-transforms': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-simple-access': 7.8.3
@@ -596,9 +597,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==
-  /@babel/plugin-transform-modules-systemjs/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-modules-systemjs/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-hoist-variables': 7.8.3
       '@babel/helper-module-transforms': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
@@ -608,9 +609,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==
-  /@babel/plugin-transform-modules-umd/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-modules-umd/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-module-transforms': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
@@ -618,27 +619,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.8.4
+      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==
-  /@babel/plugin-transform-new-target/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-new-target/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==
-  /@babel/plugin-transform-object-super/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-object-super/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-replace-supers': 7.8.3
     dev: true
@@ -646,9 +647,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==
-  /@babel/plugin-transform-parameters/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-parameters/7.8.4_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-call-delegate': 7.8.3
       '@babel/helper-get-function-arity': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
@@ -656,107 +657,107 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==
-  /@babel/plugin-transform-property-literals/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==
+  /@babel/plugin-transform-property-literals/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==
-  /@babel/plugin-transform-react-display-name/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-react-display-name/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==
-  /@babel/plugin-transform-react-jsx-self/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-react-jsx-self/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-01OT7s5oa0XTLf2I8XGsL8+KqV9lx3EZV+jxn/L2LQ97CGKila2YMroTkCEIE0HV/FF7CMSRsIAybopdN9NTdg==
-  /@babel/plugin-transform-react-jsx-source/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-react-jsx-source/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-PLMgdMGuVDtRS/SzjNEQYUT8f4z1xb2BAT54vM1X5efkVuYBf5WyGUMbpmARcfq3NaglIwz08UVQK4HHHbC6ag==
-  /@babel/plugin-transform-react-jsx/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-react-jsx/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-builder-react-jsx': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-syntax-jsx': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-r0h+mUiyL595ikykci+fbwm9YzmuOrUBi0b+FDIKmi3fPQyFokWVEMJnRWHJPPQEjyFJyna9WZC6Viv6UHSv1g==
-  /@babel/plugin-transform-regenerator/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-regenerator/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       regenerator-transform: 0.14.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==
-  /@babel/plugin-transform-reserved-words/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-reserved-words/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==
-  /@babel/plugin-transform-runtime/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-runtime/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
-      resolve: 1.14.2
+      resolve: 1.15.0
       semver: 5.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==
-  /@babel/plugin-transform-shorthand-properties/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-shorthand-properties/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==
-  /@babel/plugin-transform-spread/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-spread/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==
-  /@babel/plugin-transform-sticky-regex/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-sticky-regex/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
       '@babel/helper-regex': 7.8.3
     dev: true
@@ -764,9 +765,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==
-  /@babel/plugin-transform-template-literals/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-template-literals/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-annotate-as-pure': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
@@ -774,19 +775,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==
-  /@babel/plugin-transform-typeof-symbol/7.8.3_@babel+core@7.8.3:
+  /@babel/plugin-transform-typeof-symbol/7.8.4_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==
-  /@babel/plugin-transform-unicode-regex/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==
+  /@babel/plugin-transform-unicode-regex/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.3
+      '@babel/core': 7.8.4
+      '@babel/helper-create-regexp-features-plugin': 7.8.3_@babel+core@7.8.4
       '@babel/helper-plugin-utils': 7.8.3
     dev: true
     peerDependencies:
@@ -800,119 +801,119 @@ packages:
     dev: true
     resolution:
       integrity: sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==
-  /@babel/preset-env/7.8.3_@babel+core@7.8.3:
+  /@babel/preset-env/7.8.4_@babel+core@7.8.4:
     dependencies:
-      '@babel/compat-data': 7.8.1
-      '@babel/core': 7.8.3
-      '@babel/helper-compilation-targets': 7.8.3_@babel+core@7.8.3
+      '@babel/compat-data': 7.8.5
+      '@babel/core': 7.8.4
+      '@babel/helper-compilation-targets': 7.8.4_@babel+core@7.8.4
       '@babel/helper-module-imports': 7.8.3
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-proposal-async-generator-functions': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-dynamic-import': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-json-strings': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-object-rest-spread': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-optional-catch-binding': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-optional-chaining': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-unicode-property-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.3
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-top-level-await': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-arrow-functions': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-async-to-generator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-block-scoped-functions': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-block-scoping': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-classes': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-computed-properties': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-destructuring': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-duplicate-keys': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-exponentiation-operator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-for-of': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-function-name': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-member-expression-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-amd': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-commonjs': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-systemjs': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-modules-umd': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-new-target': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-object-super': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-parameters': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-property-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-regenerator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-reserved-words': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-shorthand-properties': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-sticky-regex': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-template-literals': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-typeof-symbol': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-unicode-regex': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-proposal-async-generator-functions': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-dynamic-import': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-json-strings': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-object-rest-spread': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-optional-catch-binding': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-optional-chaining': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.8.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-top-level-await': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-arrow-functions': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-async-to-generator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-block-scoped-functions': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-block-scoping': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-classes': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-computed-properties': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-destructuring': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-dotall-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-duplicate-keys': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-exponentiation-operator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-for-of': 7.8.4_@babel+core@7.8.4
+      '@babel/plugin-transform-function-name': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-member-expression-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-amd': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-commonjs': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-systemjs': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-modules-umd': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-new-target': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-object-super': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-parameters': 7.8.4_@babel+core@7.8.4
+      '@babel/plugin-transform-property-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-regenerator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-reserved-words': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-shorthand-properties': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-sticky-regex': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-template-literals': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-typeof-symbol': 7.8.4_@babel+core@7.8.4
+      '@babel/plugin-transform-unicode-regex': 7.8.3_@babel+core@7.8.4
       '@babel/types': 7.8.3
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       core-js-compat: 3.6.4
       invariant: 2.2.4
-      levenary: 1.1.0
+      levenary: 1.1.1
       semver: 5.7.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==
-  /@babel/preset-react/7.8.3_@babel+core@7.8.3:
+      integrity: sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==
+  /@babel/preset-react/7.8.3_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       '@babel/helper-plugin-utils': 7.8.3
-      '@babel/plugin-transform-react-display-name': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-react-jsx': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-react-jsx-self': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-react-jsx-source': 7.8.3_@babel+core@7.8.3
+      '@babel/plugin-transform-react-display-name': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-react-jsx': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-react-jsx-self': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-react-jsx-source': 7.8.3_@babel+core@7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9hx0CwZg92jGb7iHYQVgi0tOEHP/kM60CtWJQnmbATSPIQQ2xYzfoCI3EdqAhFBeeJwYMdWQuDUHMsuDbH9hyQ==
-  /@babel/runtime-corejs3/7.8.3:
+  /@babel/runtime-corejs3/7.8.4:
     dependencies:
       core-js-pure: 3.6.4
       regenerator-runtime: 0.13.3
     dev: true
     resolution:
-      integrity: sha512-lrIU4aVbmlM/wQPzhEvzvNJskKyYptuXb0fGC0lTQTupTOYtR2Vqbu6/jf8vTr4M8Wt1nIzxVrSvPI5qESa/xA==
-  /@babel/runtime/7.8.3:
+      integrity: sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==
+  /@babel/runtime/7.8.4:
     dependencies:
       regenerator-runtime: 0.13.3
     dev: true
     resolution:
-      integrity: sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+      integrity: sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
   /@babel/template/7.8.3:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/parser': 7.8.3
+      '@babel/parser': 7.8.4
       '@babel/types': 7.8.3
     dev: true
     resolution:
       integrity: sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==
-  /@babel/traverse/7.8.3:
+  /@babel/traverse/7.8.4:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/generator': 7.8.3
+      '@babel/generator': 7.8.4
       '@babel/helper-function-name': 7.8.3
       '@babel/helper-split-export-declaration': 7.8.3
-      '@babel/parser': 7.8.3
+      '@babel/parser': 7.8.4
       '@babel/types': 7.8.3
       debug: 4.1.1
       globals: 11.12.0
       lodash: 4.17.15
     dev: true
     resolution:
-      integrity: sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==
+      integrity: sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==
   /@babel/types/7.8.3:
     dependencies:
       esutils: 2.0.3
@@ -956,13 +957,13 @@ packages:
       eslint: ^6.8.0
     resolution:
       integrity: sha512-NQ8IT2PCiY/I8eGHQiquHs7EWrWZAG9pYSwR3S6bsiR2TCXv0UYBGcCXp/Z6WHYylKym0PA+95ZWWqCyD4muCg==
-  /@jtechsvcs/eslint-config-typescript/2.0.1_0ed20ba8bdc1aaaf6c2385c42cfe57ae:
+  /@jtechsvcs/eslint-config-typescript/2.0.3_0e623a8db94d98d9fac7066b18561e21:
     dependencies:
       '@jtechsvcs/eslint-config-standard': 2.0.0_eslint@6.8.0
       '@jtechsvcs/eslint-merge-config': 1.0.2
-      '@typescript-eslint/eslint-plugin': 2.16.0_06dd01ff8bc3edf7e85377823fd48c83
-      '@typescript-eslint/parser': 2.16.0_eslint@6.8.0+typescript@3.7.5
-      '@typescript-eslint/typescript-estree': 2.16.0_typescript@3.7.5
+      '@typescript-eslint/eslint-plugin': 2.19.0_25db45452788e415134bad7c0cac009a
+      '@typescript-eslint/parser': 2.19.0_eslint@6.8.0+typescript@3.7.5
+      '@typescript-eslint/typescript-estree': 2.19.0_typescript@3.7.5
       eslint: 6.8.0
     dev: true
     peerDependencies:
@@ -971,7 +972,7 @@ packages:
       '@typescript-eslint/typescript-estree': ^2.16.0
       eslint: ^6.8.0
     resolution:
-      integrity: sha512-ESnp5SNZJ/M7NiF3xawZ3raGbDsgefWur90hkwNG1cKkwfGBw9mLnNZmicPEQhxA6dGwV/FDPz0ovZD7/oE9RQ==
+      integrity: sha512-2+mGRwFy2PCryHYHSzqxIx93RO2Uw4hdm0oNQ0Ky3VwFgGMjdfISalwREHCRmjkGaJXXO7ykJpKwE9i3sJcQ1Q==
   /@jtechsvcs/eslint-merge-config/1.0.2:
     dev: true
     resolution:
@@ -1043,12 +1044,16 @@ packages:
       integrity: sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
   /@szmarczak/http-timer/1.1.2:
     dependencies:
-      defer-to-connect: 1.1.1
+      defer-to-connect: 1.1.3
     dev: true
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+  /@types/anymatch/1.3.1:
+    dev: true
+    resolution:
+      integrity: sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
   /@types/color-name/1.1.1:
     dev: true
     resolution:
@@ -1077,7 +1082,7 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 12.12.25
+      '@types/node': 12.12.26
     dev: true
     resolution:
       integrity: sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==
@@ -1085,14 +1090,14 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 12.12.25
+      '@types/node': 12.12.26
     dev: true
     resolution:
       integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
-  /@types/history/4.7.4:
+  /@types/history/4.7.5:
     dev: true
     resolution:
-      integrity: sha512-+o2igcuZA3xtOoFH56s+MCZVidwlJNcJID57DSCyawS2i910yG9vkwehCjJNZ6ImhCR5S9DbvIJKyYHcMyOfMw==
+      integrity: sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
   /@types/json-schema/7.0.4:
     dev: true
     resolution:
@@ -1105,10 +1110,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
-  /@types/node/12.12.25:
+  /@types/node/12.12.26:
     dev: true
     resolution:
-      integrity: sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==
+      integrity: sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==
   /@types/node/7.10.9:
     dev: true
     resolution:
@@ -1127,26 +1132,59 @@ packages:
       integrity: sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
   /@types/reach__router/1.2.6:
     dependencies:
-      '@types/history': 4.7.4
-      '@types/react': 16.9.17
+      '@types/history': 4.7.5
+      '@types/react': 16.9.19
     dev: true
     resolution:
       integrity: sha512-Oh5DAVr/L2svBvubw6QEFpXGu295Y406BPs4i9t1n2pp7M+q3pmCmhzb9oZV5wncR41KCD3NHl1Yhi7uKnTPsA==
-  /@types/react/16.9.17:
+  /@types/react/16.9.19:
     dependencies:
       '@types/prop-types': 15.7.3
       csstype: 2.6.8
     dev: true
     resolution:
-      integrity: sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==
+      integrity: sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==
+  /@types/source-list-map/0.1.2:
+    dev: true
+    resolution:
+      integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+  /@types/tapable/1.0.5:
+    dev: true
+    resolution:
+      integrity: sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
   /@types/tmp/0.0.32:
     dev: true
     resolution:
       integrity: sha1-DTyzECL4Qn6ljACK8yuA2hJspOM=
-  /@typescript-eslint/eslint-plugin/2.16.0_06dd01ff8bc3edf7e85377823fd48c83:
+  /@types/uglify-js/3.0.4:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.16.0_eslint@6.8.0+typescript@3.7.5
-      '@typescript-eslint/parser': 2.16.0_eslint@6.8.0+typescript@3.7.5
+      source-map: 0.6.1
+    dev: true
+    resolution:
+      integrity: sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
+  /@types/webpack-sources/0.1.6:
+    dependencies:
+      '@types/node': 12.12.26
+      '@types/source-list-map': 0.1.2
+      source-map: 0.6.1
+    dev: true
+    resolution:
+      integrity: sha512-FtAWR7wR5ocJ9+nP137DV81tveD/ZgB1sadnJ/axUGM3BUVfRPx8oQNMtv3JNfTeHx3VP7cXiyfR/jmtEsVHsQ==
+  /@types/webpack/4.41.5:
+    dependencies:
+      '@types/anymatch': 1.3.1
+      '@types/node': 12.12.26
+      '@types/tapable': 1.0.5
+      '@types/uglify-js': 3.0.4
+      '@types/webpack-sources': 0.1.6
+      source-map: 0.6.1
+    dev: true
+    resolution:
+      integrity: sha512-693JfV/83UZxpQY8vutDSwkDjNujy2327UrFqQciJWXh761B/aUIZIM5N05IRIZ17WwsG8VfUSE3edwXvkehiQ==
+  /@typescript-eslint/eslint-plugin/2.19.0_25db45452788e415134bad7c0cac009a:
+    dependencies:
+      '@typescript-eslint/experimental-utils': 2.19.0_eslint@6.8.0+typescript@3.7.5
+      '@typescript-eslint/parser': 2.19.0_eslint@6.8.0+typescript@3.7.5
       eslint: 6.8.0
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
@@ -1164,11 +1202,11 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-TKWbeFAKRPrvKiR9GNxErQ8sELKqg1ZvXi6uho07mcKShBnCnqNpDQWP01FEvWKf0bxM2g7uQEI5MNjSNqvUpQ==
-  /@typescript-eslint/experimental-utils/2.16.0_eslint@6.8.0+typescript@3.7.5:
+      integrity: sha512-u7IcQ9qwsB6U806LupZmINRnQjC+RJyv36sV/ugaFWMHTbFm/hlLTRx3gGYJgHisxcGSTnf+I/fPDieRMhPSQQ==
+  /@typescript-eslint/experimental-utils/2.19.0_eslint@6.8.0+typescript@3.7.5:
     dependencies:
       '@types/json-schema': 7.0.4
-      '@typescript-eslint/typescript-estree': 2.16.0_typescript@3.7.5
+      '@typescript-eslint/typescript-estree': 2.19.0_typescript@3.7.5
       eslint: 6.8.0
       eslint-scope: 5.0.0
     dev: true
@@ -1178,12 +1216,12 @@ packages:
       eslint: '*'
       typescript: '*'
     resolution:
-      integrity: sha512-bXTmAztXpqxliDKZgvWkl+5dHeRN+jqXVZ16peKKFzSXVzT6mz8kgBpHiVzEKO2NZ8OCU7dG61K9sRS/SkUUFQ==
-  /@typescript-eslint/parser/2.16.0_eslint@6.8.0+typescript@3.7.5:
+      integrity: sha512-zwpg6zEOPbhB3+GaQfufzlMUOO6GXCNZq6skk+b2ZkZAIoBhVoanWK255BS1g5x9bMwHpLhX0Rpn5Fc3NdCZdg==
+  /@typescript-eslint/parser/2.19.0_eslint@6.8.0+typescript@3.7.5:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.16.0_eslint@6.8.0+typescript@3.7.5
-      '@typescript-eslint/typescript-estree': 2.16.0_typescript@3.7.5
+      '@typescript-eslint/experimental-utils': 2.19.0_eslint@6.8.0+typescript@3.7.5
+      '@typescript-eslint/typescript-estree': 2.19.0_typescript@3.7.5
       eslint: 6.8.0
       eslint-visitor-keys: 1.1.0
       typescript: 3.7.5
@@ -1197,8 +1235,8 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-+w8dMaYETM9v6il1yYYkApMSiwgnqXWJbXrA94LAWN603vXHACsZTirJduyeBOJjA9wT6xuXe5zZ1iCUzoxCfw==
-  /@typescript-eslint/typescript-estree/2.16.0_typescript@3.7.5:
+      integrity: sha512-s0jZoxAWjHnuidbbN7aA+BFVXn4TCcxEVGPV8lWMxZglSs3NRnFFAlL+aIENNmzB2/1jUJuySi6GiM6uACPmpg==
+  /@typescript-eslint/typescript-estree/2.19.0_typescript@3.7.5:
     dependencies:
       debug: 4.1.1
       eslint-visitor-keys: 1.1.0
@@ -1217,7 +1255,7 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-hyrCYjFHISos68Bk5KjUAXw0pP/455qq9nxqB1KkT67Pxjcfw+r6Yhcmqnp8etFL45UexCHUMrADHH7dI/m2WQ==
+      integrity: sha512-n6/Xa37k0jQdwpUszffi19AlNbVCR0sdvCs3DmSKMD7wBttKY31lhD2fug5kMD91B2qW4mQldaTEc1PEzvGu8w==
   /@webassemblyjs/ast/1.8.5:
     dependencies:
       '@webassemblyjs/helper-module-context': 1.8.5
@@ -1410,31 +1448,31 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
-  /ajv-errors/1.0.1_ajv@6.10.2:
+  /ajv-errors/1.0.1_ajv@6.11.0:
     dependencies:
-      ajv: 6.10.2
+      ajv: 6.11.0
     dev: true
     peerDependencies:
       ajv: '>=5.0.0'
     resolution:
       integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
-  /ajv-keywords/3.4.1_ajv@6.10.2:
+  /ajv-keywords/3.4.1_ajv@6.11.0:
     dependencies:
-      ajv: 6.10.2
+      ajv: 6.11.0
     dev: true
     peerDependencies:
       ajv: ^6.9.1
     resolution:
       integrity: sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
-  /ajv/6.10.2:
+  /ajv/6.11.0:
     dependencies:
-      fast-deep-equal: 2.0.1
+      fast-deep-equal: 3.1.1
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.2.2
     dev: true
     resolution:
-      integrity: sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
+      integrity: sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
   /alphanum-sort/1.0.2:
     dev: true
     resolution:
@@ -1595,7 +1633,7 @@ packages:
   /array-includes/3.1.1:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
       is-string: 1.0.5
     dev: true
     engines:
@@ -1639,7 +1677,7 @@ packages:
   /array.prototype.flat/1.2.3:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
     dev: true
     engines:
       node: '>= 0.4'
@@ -1723,22 +1761,17 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
-  /auto-bind/3.0.0:
+  /auto-bind/4.0.0:
     dev: true
     engines:
       node: '>=8'
     optional: true
-    peerDependencies:
-      '@types/react': '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
     resolution:
-      integrity: sha512-v0A231a/lfOo6kxQtmEkdBfTApvC21aJYukA8pkKnoTvVqh3Wmm7/Rwy4GBCHTTHVoLVA5qsBDDvf1XY1nIV2g==
+      integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==
   /autoprefixer/9.7.4:
     dependencies:
-      browserslist: 4.8.3
-      caniuse-lite: 1.0.30001021
+      browserslist: 4.8.6
+      caniuse-lite: 1.0.30001025
       chalk: 2.4.2
       normalize-range: 0.1.2
       num2fraction: 1.2.2
@@ -1750,16 +1783,16 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==
-  /axios/0.19.1:
+  /axios/0.19.2:
     dependencies:
       follow-redirects: 1.5.10
     dev: true
     resolution:
-      integrity: sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==
+      integrity: sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   /axobject-query/2.1.1_eslint@6.8.0:
     dependencies:
-      '@babel/runtime': 7.8.3
-      '@babel/runtime-corejs3': 7.8.3
+      '@babel/runtime': 7.8.4
+      '@babel/runtime-corejs3': 7.8.4
       eslint: 6.8.0
     dev: true
     peerDependencies:
@@ -1774,9 +1807,9 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
-  /babel-core/7.0.0-bridge.0_@babel+core@7.8.3:
+  /babel-core/7.0.0-bridge.0_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1785,12 +1818,12 @@ packages:
   /babel-eslint/10.0.3_eslint@6.8.0:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/parser': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/parser': 7.8.4
+      '@babel/traverse': 7.8.4
       '@babel/types': 7.8.3
       eslint: 6.8.0
       eslint-visitor-keys: 1.1.0
-      resolve: 1.14.2
+      resolve: 1.15.0
     dev: true
     engines:
       node: '>=6'
@@ -1798,9 +1831,9 @@ packages:
       eslint: '>= 4.12.1'
     resolution:
       integrity: sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
-  /babel-loader/8.0.6_@babel+core@7.8.3+webpack@4.41.5:
+  /babel-loader/8.0.6_@babel+core@7.8.4+webpack@4.41.5:
     dependencies:
-      '@babel/core': 7.8.3
+      '@babel/core': 7.8.4
       find-cache-dir: 2.1.0
       loader-utils: 1.2.3
       mkdirp: 0.5.1
@@ -1828,16 +1861,16 @@ packages:
       integrity: sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
   /babel-plugin-macros/2.8.0:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       cosmiconfig: 6.0.0
-      resolve: 1.14.2
+      resolve: 1.15.0
     dev: true
     resolution:
       integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
-  /babel-plugin-remove-graphql-queries/2.7.22_gatsby@2.18.25+graphql@14.5.8:
+  /babel-plugin-remove-graphql-queries/2.7.23_gatsby@2.19.12+graphql@14.6.0:
     dependencies:
-      gatsby: 2.18.25_gatsby@2.18.25+typescript@3.7.5
-      graphql: 14.5.8
+      gatsby: 2.19.12_gatsby@2.19.12+typescript@3.7.5
+      graphql: 14.6.0
     dev: true
     engines:
       node: '>=8.0.0'
@@ -1845,23 +1878,23 @@ packages:
       gatsby: ^2.0.0
       graphql: ^14.1.1
     resolution:
-      integrity: sha512-gb4bKZvePZME/VRBMiIZfnli1BIO0K8cm1Pj9HPm85PqElPHzdjeUZ9p3ybOCGe+BBpIlqKx7mx9V/RsjlH+SA==
+      integrity: sha512-SvWLivXtbeExS0eUPrRpg8EYiDPcOlzaO/vePcdmW2X8GBC1miezXS+RYPYyt4r9Z0Cg0ZQe58ggssF/8ym3rg==
   /babel-plugin-transform-react-remove-prop-types/0.4.24:
     dev: true
     resolution:
       integrity: sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
-  /babel-preset-gatsby/0.2.27_@babel+core@7.8.3:
+  /babel-preset-gatsby/0.2.28_@babel+core@7.8.4:
     dependencies:
-      '@babel/core': 7.8.3
-      '@babel/plugin-proposal-class-properties': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-proposal-optional-chaining': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-runtime': 7.8.3_@babel+core@7.8.3
-      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.3
-      '@babel/preset-env': 7.8.3_@babel+core@7.8.3
-      '@babel/preset-react': 7.8.3_@babel+core@7.8.3
-      '@babel/runtime': 7.8.3
+      '@babel/core': 7.8.4
+      '@babel/plugin-proposal-class-properties': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-proposal-optional-chaining': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-runtime': 7.8.3_@babel+core@7.8.4
+      '@babel/plugin-transform-spread': 7.8.3_@babel+core@7.8.4
+      '@babel/preset-env': 7.8.4_@babel+core@7.8.4
+      '@babel/preset-react': 7.8.3_@babel+core@7.8.4
+      '@babel/runtime': 7.8.4
       babel-plugin-dynamic-import-node: 2.3.0
       babel-plugin-macros: 2.8.0
       babel-plugin-transform-react-remove-prop-types: 0.4.24
@@ -1871,7 +1904,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-BXoUhKfBZUQb6nR5/fmQeNpKN137eucvRvKUGYcz9ZPbJOALSek03wseJA4zK8rV+mIQYM47y+AFs09RU/aOHg==
+      integrity: sha512-PnQgmGHTgGHgMmTeK1raV5rFk4puUX2bX0L7Ayqomi5xMQqQXLYOeE5bsaB1YIBpdFMdCUgbf9skX7vfqyy7hw==
   /babel-runtime/6.26.0:
     dependencies:
       core-js: 2.6.11
@@ -2042,7 +2075,7 @@ packages:
       chalk: 3.0.0
       cli-boxes: 2.2.0
       string-width: 4.2.0
-      term-size: 2.1.1
+      term-size: 2.2.0
       type-fest: 0.8.1
       widest-line: 3.1.0
     dev: true
@@ -2135,27 +2168,27 @@ packages:
       integrity: sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
   /browserify-zlib/0.2.0:
     dependencies:
-      pako: 1.0.10
+      pako: 1.0.11
     dev: true
     resolution:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30001021
-      electron-to-chromium: 1.3.337
+      caniuse-lite: 1.0.30001025
+      electron-to-chromium: 1.3.345
     dev: true
     hasBin: true
     resolution:
       integrity: sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
-  /browserslist/4.8.3:
+  /browserslist/4.8.6:
     dependencies:
-      caniuse-lite: 1.0.30001021
-      electron-to-chromium: 1.3.337
-      node-releases: 1.1.45
+      caniuse-lite: 1.0.30001025
+      electron-to-chromium: 1.3.345
+      node-releases: 1.1.47
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==
+      integrity: sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
   /buffer-alloc-unsafe/1.1.0:
     dev: true
     resolution:
@@ -2258,13 +2291,14 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-7X+FPItAJf1tKKqJx6ljDJQc0fgSR5B+KPxFQLj+vYSL4q9XdrCbZldgsNb6wueRuIooj01wt0FubB08zaefRg==
-  /cache-manager/2.10.1:
+  /cache-manager/2.11.1:
     dependencies:
       async: 1.5.2
+      lodash.clonedeep: 4.5.0
       lru-cache: 4.0.0
     dev: true
     resolution:
-      integrity: sha512-bk17v9IkLqNcbCzggEh82LEJhjHp+COnL57L7a0ESbM/cOuXIIBatdVjD/ps7vOsofI48++zAC14Ye+8v50flg==
+      integrity: sha512-XhUuc9eYwkzpK89iNewFwtvcDYMUsvtwzHeyEOPJna/WsVsXcrzsA1ft2M0QqPNunEzLhNCYPo05tEfG+YuNow==
   /cacheable-request/2.1.4:
     dependencies:
       clone-response: 1.0.2
@@ -2331,17 +2365,17 @@ packages:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
   /caniuse-api/3.0.0:
     dependencies:
-      browserslist: 4.8.3
-      caniuse-lite: 1.0.30001021
+      browserslist: 4.8.6
+      caniuse-lite: 1.0.30001025
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: true
     resolution:
       integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
-  /caniuse-lite/1.0.30001021:
+  /caniuse-lite/1.0.30001025:
     dev: true
     resolution:
-      integrity: sha512-wuMhT7/hwkgd8gldgp2jcrUjOU9RXJ4XxGumQeOsUr91l3WwmM68Cpa/ymCnWEDqakwFXhuDQbaKNHXBPgeE9g==
+      integrity: sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==
   /chalk/1.1.3:
     dependencies:
       ansi-styles: 2.2.1
@@ -2819,7 +2853,7 @@ packages:
       integrity: sha512-iJbHJI+8OKqsq+4JF0rqgRkZzo++jqO6Wf4FUU1JM41cJF6JcY5968XyF4tm3Kkm7ZOMrqlljdm8N9oyY5raGw==
   /core-js-compat/3.6.4:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       semver: 7.0.0
     dev: true
     resolution:
@@ -3182,10 +3216,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
-  /damerau-levenshtein/1.0.5:
+  /damerau-levenshtein/1.0.6:
     dev: true
     resolution:
-      integrity: sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==
+      integrity: sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
   /debug/2.6.9:
     dependencies:
       ms: 2.0.0
@@ -3260,10 +3294,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==
-  /defer-to-connect/1.1.1:
+  /defer-to-connect/1.1.3:
     dev: true
     resolution:
-      integrity: sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==
+      integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
   /define-properties/1.1.3:
     dependencies:
       object-keys: 1.1.1
@@ -3319,7 +3353,7 @@ packages:
       is-path-cwd: 2.2.0
       is-path-inside: 3.0.2
       p-map: 3.0.0
-      rimraf: 3.0.0
+      rimraf: 3.0.1
       slash: 3.0.0
     dev: true
     engines:
@@ -3460,7 +3494,7 @@ packages:
       integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   /dom-helpers/3.4.0:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
     dev: true
     resolution:
       integrity: sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
@@ -3553,10 +3587,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.337:
+  /electron-to-chromium/1.3.345:
     dev: true
     resolution:
-      integrity: sha512-uJ+wLjslYQ/2rAusDg+6FlK8DLhHWTLCe7gkofBehTifW7KCkPVTn5rhKSCncWYNq34Iy/o4OfswuEkAO2RBaw==
+      integrity: sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==
   /elliptic/6.5.2:
     dependencies:
       bn.js: 4.11.8
@@ -3686,7 +3720,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
-  /es-abstract/1.17.2:
+  /es-abstract/1.17.4:
     dependencies:
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
@@ -3703,7 +3737,7 @@ packages:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==
+      integrity: sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==
   /es-to-primitive/1.2.1:
     dependencies:
       is-callable: 1.1.5
@@ -3728,17 +3762,17 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-  /eslint-config-react-app/5.1.0_47ed02ef445c8a04e699fd52e0a94700:
+  /eslint-config-react-app/5.2.0_ca865965511240483304dceacefc4940:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 2.16.0_06dd01ff8bc3edf7e85377823fd48c83
-      '@typescript-eslint/parser': 2.16.0_eslint@6.8.0+typescript@3.7.5
+      '@typescript-eslint/eslint-plugin': 2.19.0_25db45452788e415134bad7c0cac009a
+      '@typescript-eslint/parser': 2.19.0_eslint@6.8.0+typescript@3.7.5
       babel-eslint: 10.0.3_eslint@6.8.0
       confusing-browser-globals: 1.0.9
       eslint: 6.8.0
       eslint-plugin-flowtype: 3.13.0_eslint@6.8.0
-      eslint-plugin-import: 2.20.0_eslint@6.8.0
+      eslint-plugin-import: 2.20.1_eslint@6.8.0
       eslint-plugin-jsx-a11y: 6.2.3_eslint@6.8.0
-      eslint-plugin-react: 7.18.0_eslint@6.8.0
+      eslint-plugin-react: 7.18.3_eslint@6.8.0
       eslint-plugin-react-hooks: 1.7.0_eslint@6.8.0
     dev: true
     peerDependencies:
@@ -3752,11 +3786,11 @@ packages:
       eslint-plugin-react: 7.x
       eslint-plugin-react-hooks: 1.x
     resolution:
-      integrity: sha512-hBaxisHC6HXRVvxX+/t1n8mOdmCVIKgkXsf2WoUkJi7upHJTwYTsdCmx01QPOjKNT34QMQQ9sL0tVBlbiMFjxA==
+      integrity: sha512-WrHjoGpKr1kLLiWDD81tme9jMM0hk5cMxasLSdyno6DdPt+IfLOrDJBVo6jN7tn4y1nzhs43TmUaZWO6Sf0blw==
   /eslint-import-resolver-node/0.3.3:
     dependencies:
       debug: 2.6.9
-      resolve: 1.14.2
+      resolve: 1.15.0
     dev: true
     resolution:
       integrity: sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==
@@ -3795,10 +3829,10 @@ packages:
       eslint: '>=5.0.0'
     resolution:
       integrity: sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==
-  /eslint-plugin-graphql/3.1.1_graphql@14.5.8:
+  /eslint-plugin-graphql/3.1.1_graphql@14.6.0:
     dependencies:
-      graphql: 14.5.8
-      graphql-config: 2.2.1_graphql@14.5.8
+      graphql: 14.6.0
+      graphql-config: 2.2.1_graphql@14.6.0
       lodash: 4.17.15
     dev: true
     engines:
@@ -3807,7 +3841,7 @@ packages:
       graphql: ^0.12.0 || ^0.13.0 || ^14.0.0
     resolution:
       integrity: sha512-VNu2AipS8P1BAnE/tcJ2EmBWjFlCnG+1jKdUlFNDQjocWZlFiPpMu9xYNXePoEXK+q+jG51M/6PdhOjEgJZEaQ==
-  /eslint-plugin-import/2.20.0_eslint@6.8.0:
+  /eslint-plugin-import/2.20.1_eslint@6.8.0:
     dependencies:
       array-includes: 3.1.1
       array.prototype.flat: 1.2.3
@@ -3821,22 +3855,22 @@ packages:
       minimatch: 3.0.4
       object.values: 1.1.1
       read-pkg-up: 2.0.0
-      resolve: 1.14.2
+      resolve: 1.15.0
     dev: true
     engines:
       node: '>=4'
     peerDependencies:
       eslint: 2.x - 6.x
     resolution:
-      integrity: sha512-NK42oA0mUc8Ngn4kONOPsPB1XhbUvNHqF+g307dPV28aknPoiNnKLFd9em4nkswwepdF5ouieqv5Th/63U7YJQ==
+      integrity: sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==
   /eslint-plugin-jsx-a11y/6.2.3_eslint@6.8.0:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       aria-query: 3.0.0
       array-includes: 3.1.1
       ast-types-flow: 0.0.7
       axobject-query: 2.1.1_eslint@6.8.0
-      damerau-levenshtein: 1.0.5
+      damerau-levenshtein: 1.0.6
       emoji-regex: 7.0.3
       eslint: 6.8.0
       has: 1.0.3
@@ -3858,7 +3892,7 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
-  /eslint-plugin-react/7.18.0_eslint@6.8.0:
+  /eslint-plugin-react/7.18.3_eslint@6.8.0:
     dependencies:
       array-includes: 3.1.1
       doctrine: 2.1.0
@@ -3869,14 +3903,15 @@ packages:
       object.fromentries: 2.0.2
       object.values: 1.1.1
       prop-types: 15.7.2
-      resolve: 1.14.2
+      resolve: 1.15.0
+      string.prototype.matchall: 4.0.2
     dev: true
     engines:
       node: '>=4'
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     resolution:
-      integrity: sha512-p+PGoGeV4SaZRDsXqdj9OWcOrOpZn8gXoGPcIQTzo2IDMbAKhNDnME9myZWqO3Ic4R3YmwAZ1lDjWl2R2hMUVQ==
+      integrity: sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==
   /eslint-scope/4.0.3:
     dependencies:
       esrecurse: 4.2.1
@@ -3912,7 +3947,7 @@ packages:
   /eslint/6.8.0:
     dependencies:
       '@babel/code-frame': 7.8.3
-      ajv: 6.10.2
+      ajv: 6.11.0
       chalk: 2.4.2
       cross-spawn: 6.0.5
       debug: 4.1.1
@@ -3930,7 +3965,7 @@ packages:
       ignore: 4.0.6
       import-fresh: 3.2.1
       imurmurhash: 0.1.4
-      inquirer: 7.0.3
+      inquirer: 7.0.4
       is-glob: 4.0.1
       js-yaml: 3.13.1
       json-stable-stringify-without-jsonify: 1.0.1
@@ -4109,11 +4144,11 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=
-  /express-graphql/0.9.0_graphql@14.5.8:
+  /express-graphql/0.9.0_graphql@14.6.0:
     dependencies:
       accepts: 1.3.7
       content-type: 1.0.4
-      graphql: 14.5.8
+      graphql: 14.6.0
       http-errors: 1.7.3
       raw-body: 2.4.1
     dev: true
@@ -4212,10 +4247,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
-  /fast-deep-equal/2.0.1:
+  /fast-deep-equal/3.1.1:
     dev: true
     resolution:
-      integrity: sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+      integrity: sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
   /fast-glob/3.1.1:
     dependencies:
       '@nodelib/fs.stat': 2.0.3
@@ -4431,6 +4466,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==
+  /follow-redirects/1.10.0:
+    dependencies:
+      debug: 3.2.6
+    dev: true
+    engines:
+      node: '>=4.0'
+    resolution:
+      integrity: sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==
   /follow-redirects/1.5.10:
     dependencies:
       debug: 3.1.0
@@ -4439,14 +4482,6 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  /follow-redirects/1.9.0:
-    dependencies:
-      debug: 3.2.6
-    dev: true
-    engines:
-      node: '>=4.0'
-    resolution:
-      integrity: sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
   /for-in/1.0.2:
     dev: true
     engines:
@@ -4535,10 +4570,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
-  /gatsby-cli/2.8.27:
+  /gatsby-cli/2.8.29:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       '@hapi/joi': 15.1.1
       better-opn: 1.0.0
       bluebird: 3.7.2
@@ -4552,8 +4587,8 @@ packages:
       execa: 3.4.0
       fs-exists-cached: 1.0.0
       fs-extra: 8.1.0
-      gatsby-core-utils: 1.0.26
-      gatsby-telemetry: 1.1.47
+      gatsby-core-utils: 1.0.28
+      gatsby-telemetry: 1.1.49
       hosted-git-info: 3.0.2
       is-valid-path: 0.1.1
       lodash: 4.17.15
@@ -4575,36 +4610,36 @@ packages:
       update-notifier: 3.0.1
       uuid: 3.3.3
       yargs: 12.0.5
-      yurnalist: 1.1.1
+      yurnalist: 1.1.2
     dev: true
     hasBin: true
     optionalDependencies:
-      ink: 2.6.0_react@16.12.0
-      ink-spinner: 3.0.1_ink@2.6.0+react@16.12.0
+      ink: 2.7.0_react@16.12.0
+      ink-spinner: 3.0.1_ink@2.7.0+react@16.12.0
     requiresBuild: true
     resolution:
-      integrity: sha512-bwLk3zwa2SNVqI6TWzYFTzkQzqPPBy3OdTqffROlxpm+2BqkKxNWP4NTQ1Ea6Hq0IuRI4iM4Mm7OxKf0knbbyQ==
-  /gatsby-core-utils/1.0.26:
+      integrity: sha512-HVZmb22D+Qf24rceY37MEzaPOk7v3ffw/tzu8pFkG1IoHLIJumbo2LMSJRvnd2+SUMQf1ZIVQCmbdEuaJ9Fn1A==
+  /gatsby-core-utils/1.0.28:
     dependencies:
       ci-info: 2.0.0
       node-object-hash: 2.0.0
     dev: true
     resolution:
-      integrity: sha512-NPflmXmyTcg3x2mp6cqp/51QeAHRKepfbf0X4erDsnVlewFJuGTe+25ZJvWkkwU2g1cPAxuwzlPe0jOL92iU4A==
-  /gatsby-graphiql-explorer/0.2.32:
+      integrity: sha512-XWKR9Rk2v6iQkmBsTLCdI3adyC9PCh1s5BQ85nlGitlgcVVQq98jZlQdcy0v9mJOrTuce0uf5RqkeGDWFLekoA==
+  /gatsby-graphiql-explorer/0.2.33:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
     dev: true
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-0Fzx5JOevUBtD8s94q3Pfjp0LPSVHWNijGXBfRRdcpzKPJZuvYAzVkRz5aQgx1FPavSJE8q9uC+Uo4VzyyPpJg==
-  /gatsby-link/2.2.28_1c0eea208b7baaca2957714d99183bf3:
+      integrity: sha512-prc/OU9dcrQQDRswguLuRqlBLGNZO/oadRR0rhmxVPrTVps3RyX4VDYvGBzaMhSfr4tMNAVDYP5iPjaaQz+D8A==
+  /gatsby-link/2.2.29_8ff9dae92011e0d3551bf4b587a40d87:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       '@reach/router': 1.2.1
       '@types/reach__router': 1.2.6
-      gatsby: 2.18.25_gatsby@2.18.25+typescript@3.7.5
+      gatsby: 2.19.12_gatsby@2.19.12+typescript@3.7.5
       prop-types: 15.7.2
     dev: true
     peerDependencies:
@@ -4613,15 +4648,15 @@ packages:
       react: ^16.4.2
       react-dom: ^16.4.2
     resolution:
-      integrity: sha512-G1ivEChE2eNxrPoKXR3Z27bZUWBNcL+SybJ+V0+xnR2y/w/hLe7DTOCt/UTCKgtvJ0jvQodwK7r1+HroXmsnVw==
-  /gatsby-page-utils/0.0.37_gatsby@2.18.25:
+      integrity: sha512-Yl6CIseRSaF9oLgcaLc4e95al2IQ4fHxMjKQtKRZEH4sFk0BIcLaVfqPwwWBdUK0rGkyNXqNs5lATBWqmg1FwA==
+  /gatsby-page-utils/0.0.39_gatsby@2.19.12:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       bluebird: 3.7.2
       chokidar: 3.3.0
       fs-exists-cached: 1.0.0
-      gatsby: 2.18.25_gatsby@2.18.25+typescript@3.7.5
-      gatsby-core-utils: 1.0.26
+      gatsby: 2.19.12_gatsby@2.19.12+typescript@3.7.5
+      gatsby-core-utils: 1.0.28
       glob: 7.1.6
       lodash: 4.17.15
       micromatch: 3.1.10
@@ -4629,14 +4664,14 @@ packages:
     peerDependencies:
       gatsby: ^2.0.0
     resolution:
-      integrity: sha512-kAeHm8yLYLelexOncfg/43TnbDcsfYIByP8IEeTDS7hJ+PLAxbwPTo8QvPX6sXi3F5PgpSwtqPEPGSqthRqJlw==
-  /gatsby-plugin-page-creator/2.1.38_gatsby@2.18.25:
+      integrity: sha512-lDrrenBnh5HR/9mgfhePPvCt2KueccbQu/KPYkBKlwz0hcZ/xl28cgit0Bj9Ijqx7XTMxBd2gtgvgB2QNd8jmA==
+  /gatsby-plugin-page-creator/2.1.40_gatsby@2.19.12:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       bluebird: 3.7.2
       fs-exists-cached: 1.0.0
-      gatsby: 2.18.25_gatsby@2.18.25+typescript@3.7.5
-      gatsby-page-utils: 0.0.37_gatsby@2.18.25
+      gatsby: 2.19.12_gatsby@2.19.12+typescript@3.7.5
+      gatsby-page-utils: 0.0.39_gatsby@2.19.12
       glob: 7.1.6
       lodash: 4.17.15
       micromatch: 3.1.10
@@ -4646,12 +4681,12 @@ packages:
     peerDependencies:
       gatsby: ^2.0.0
     resolution:
-      integrity: sha512-N/aIxHbjaJzed6O527Zj9sdeW3YjLs4aN3yt+rx/K121yIH6gs5TMzPdSfFTxEeXEGw4ZZijJ70MBIlK0UNdkQ==
-  /gatsby-react-router-scroll/2.1.20_1c0eea208b7baaca2957714d99183bf3:
+      integrity: sha512-jwY8LTOOobrKUr1ph+/IHAHDuzjSrXsAu2YBqZg7wc/J6gre0YAgOU2yAxY34CadE34jieISO3FDIyHMii3vPg==
+  /gatsby-react-router-scroll/2.1.21_8ff9dae92011e0d3551bf4b587a40d87:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       '@reach/router': 1.2.1
-      gatsby: 2.18.25_gatsby@2.18.25+typescript@3.7.5
+      gatsby: 2.19.12_gatsby@2.19.12+typescript@3.7.5
       scroll-behavior: 0.9.11
       warning: 3.0.0
     dev: true
@@ -4663,17 +4698,17 @@ packages:
       react: ^0.14.0 || ^15.0.0 || ^16.0.0
       react-dom: ^0.14.0 || ^15.0.0 || ^16.0.0
     resolution:
-      integrity: sha512-o4LvoV+XL8zLLFsX1rN2Und4seu2jppEcj6yb9g/f5itsPzNXMdRWW8r2fqovGRxtDJ/J6Wwx+1y3pOokMSq/A==
-  /gatsby-telemetry/1.1.47:
+      integrity: sha512-aEjj8baFlWOfgU/HGiqxKHtfEtYMnU2qDWPxbYK07xxvXqk3reUu3cluCSaO0EqNUALwJkaz2QsYLzo9MszbeA==
+  /gatsby-telemetry/1.1.49:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
       bluebird: 3.7.2
       boxen: 4.2.0
       configstore: 5.0.0
       envinfo: 7.5.0
       fs-extra: 8.1.0
-      gatsby-core-utils: 1.0.26
+      gatsby-core-utils: 1.0.28
       git-up: 4.0.1
       is-docker: 2.0.0
       lodash: 4.17.15
@@ -4688,36 +4723,36 @@ packages:
       node: '>=8.0.0'
     requiresBuild: true
     resolution:
-      integrity: sha512-vj3zGaB6Of3ExYk/VGF91qh6YcB/ofT9yYYbefO741rlK3iusv8Fzg13R8yPyRBHYOtKhgvXNbUUgH8sWHUq4Q==
-  /gatsby/2.18.25_gatsby@2.18.25+typescript@3.7.5:
+      integrity: sha512-NLT843FVp3pt1gjJ/vsclgw6h7pIKDF9l8sWBFiIrJUjiwGqCVC+emylbuK8MFE8Js989SP40piqvgo+orEl3g==
+  /gatsby/2.19.12_gatsby@2.19.12+typescript@3.7.5:
     dependencies:
       '@babel/code-frame': 7.8.3
-      '@babel/core': 7.8.3
-      '@babel/parser': 7.8.3
+      '@babel/core': 7.8.4
+      '@babel/parser': 7.8.4
       '@babel/polyfill': 7.8.3
-      '@babel/runtime': 7.8.3
-      '@babel/traverse': 7.8.3
+      '@babel/runtime': 7.8.4
+      '@babel/traverse': 7.8.4
       '@hapi/joi': 15.1.1
       '@mikaelkristiansson/domready': 1.0.10
       '@pieh/friendly-errors-webpack-plugin': 1.7.0-chalk-2_webpack@4.41.5
       '@reach/router': 1.2.1
-      '@typescript-eslint/eslint-plugin': 2.16.0_06dd01ff8bc3edf7e85377823fd48c83
-      '@typescript-eslint/parser': 2.16.0_eslint@6.8.0+typescript@3.7.5
+      '@typescript-eslint/eslint-plugin': 2.19.0_25db45452788e415134bad7c0cac009a
+      '@typescript-eslint/parser': 2.19.0_eslint@6.8.0+typescript@3.7.5
       address: 1.1.2
       autoprefixer: 9.7.4
-      axios: 0.19.1
-      babel-core: 7.0.0-bridge.0_@babel+core@7.8.3
+      axios: 0.19.2
+      babel-core: 7.0.0-bridge.0_@babel+core@7.8.4
       babel-eslint: 10.0.3_eslint@6.8.0
-      babel-loader: 8.0.6_@babel+core@7.8.3+webpack@4.41.5
+      babel-loader: 8.0.6_@babel+core@7.8.4+webpack@4.41.5
       babel-plugin-add-module-exports: 0.3.3
       babel-plugin-dynamic-import-node: 2.3.0
-      babel-plugin-remove-graphql-queries: 2.7.22_gatsby@2.18.25+graphql@14.5.8
-      babel-preset-gatsby: 0.2.27_@babel+core@7.8.3
+      babel-plugin-remove-graphql-queries: 2.7.23_gatsby@2.19.12+graphql@14.6.0
+      babel-preset-gatsby: 0.2.28_@babel+core@7.8.4
       better-opn: 1.0.0
       better-queue: 3.8.10
       bluebird: 3.7.2
       browserslist: 3.2.8
-      cache-manager: 2.10.1
+      cache-manager: 2.11.1
       cache-manager-fs-hash: 0.0.7
       chalk: 2.4.2
       chokidar: 3.3.0
@@ -4734,34 +4769,35 @@ packages:
       devcert-san: 0.3.3
       dotenv: 8.2.0
       eslint: 6.8.0
-      eslint-config-react-app: 5.1.0_47ed02ef445c8a04e699fd52e0a94700
+      eslint-config-react-app: 5.2.0_ca865965511240483304dceacefc4940
       eslint-loader: 2.2.1_eslint@6.8.0+webpack@4.41.5
       eslint-plugin-flowtype: 3.13.0_eslint@6.8.0
-      eslint-plugin-graphql: 3.1.1_graphql@14.5.8
-      eslint-plugin-import: 2.20.0_eslint@6.8.0
+      eslint-plugin-graphql: 3.1.1_graphql@14.6.0
+      eslint-plugin-import: 2.20.1_eslint@6.8.0
       eslint-plugin-jsx-a11y: 6.2.3_eslint@6.8.0
-      eslint-plugin-react: 7.18.0_eslint@6.8.0
+      eslint-plugin-react: 7.18.3_eslint@6.8.0
       eslint-plugin-react-hooks: 1.7.0_eslint@6.8.0
       event-source-polyfill: 1.0.12
       express: 4.17.1
-      express-graphql: 0.9.0_graphql@14.5.8
+      express-graphql: 0.9.0_graphql@14.6.0
       fast-levenshtein: 2.0.6
       file-loader: 1.1.11_webpack@4.41.5
       flat: 4.1.0
       fs-exists-cached: 1.0.0
       fs-extra: 8.1.0
-      gatsby-cli: 2.8.27
-      gatsby-core-utils: 1.0.26
-      gatsby-graphiql-explorer: 0.2.32
-      gatsby-link: 2.2.28_1c0eea208b7baaca2957714d99183bf3
-      gatsby-plugin-page-creator: 2.1.38_gatsby@2.18.25
-      gatsby-react-router-scroll: 2.1.20_1c0eea208b7baaca2957714d99183bf3
-      gatsby-telemetry: 1.1.47
+      gatsby-cli: 2.8.29
+      gatsby-core-utils: 1.0.28
+      gatsby-graphiql-explorer: 0.2.33
+      gatsby-link: 2.2.29_8ff9dae92011e0d3551bf4b587a40d87
+      gatsby-plugin-page-creator: 2.1.40_gatsby@2.19.12
+      gatsby-react-router-scroll: 2.1.21_8ff9dae92011e0d3551bf4b587a40d87
+      gatsby-telemetry: 1.1.49
       glob: 7.1.6
       got: 8.3.2
-      graphql: 14.5.8
-      graphql-compose: 6.3.8_graphql@14.5.8
+      graphql: 14.6.0
+      graphql-compose: 6.3.8_graphql@14.6.0
       graphql-playground-middleware-express: 1.7.12_express@4.17.1
+      hasha: 5.1.0
       invariant: 2.2.4
       is-relative: 1.0.0
       is-relative-url: 3.0.0
@@ -4784,9 +4820,10 @@ packages:
       null-loader: 0.1.1
       opentracing: 0.14.4
       optimize-css-assets-webpack-plugin: 5.0.3_webpack@4.41.5
+      p-defer: 3.0.0
       parseurl: 1.3.3
       physical-cpu-count: 2.0.0
-      pnp-webpack-plugin: 1.5.0_typescript@3.7.5
+      pnp-webpack-plugin: 1.6.0_typescript@3.7.5
       postcss-flexbugs-fixes: 3.3.1
       postcss-loader: 2.1.6
       prompts: 2.3.0
@@ -4794,7 +4831,7 @@ packages:
       raw-loader: 0.5.1
       react-dev-utils: 4.2.3
       react-error-overlay: 3.0.0
-      react-hot-loader: 4.12.18
+      react-hot-loader: 4.12.19
       redux: 4.0.5
       redux-thunk: 2.3.0
       semver: 5.7.1
@@ -4815,11 +4852,11 @@ packages:
       v8-compile-cache: 1.1.2
       webpack: 4.41.5_webpack@4.41.5
       webpack-dev-middleware: 3.7.2_webpack@4.41.5
-      webpack-dev-server: 3.10.1_webpack@4.41.5
+      webpack-dev-server: 3.10.2_webpack@4.41.5
       webpack-hot-middleware: 2.25.0
       webpack-merge: 4.2.2
       webpack-stats-plugin: 0.3.1
-      xstate: 4.7.6
+      xstate: 4.7.8
       yaml-loader: 0.5.0
     dev: true
     engines:
@@ -4832,7 +4869,7 @@ packages:
       typescript: '*'
     requiresBuild: true
     resolution:
-      integrity: sha512-mXn1OY93On6D8YDYv4qpC4S8e83EzeSnzSgISgSlyPEKilXQYdAYNJn+QdfC74dLsm7lsaDeLKcb8PIjegaiQw==
+      integrity: sha512-oI76KUEIebmaVOwtHuRINBspLvKHCIOdVPiNdgT/ly05iJLg9OsKd6/eYZ/rO+YYWew8t+MmoMVmRLpaWE2RBQ==
   /gensync/1.0.0-beta.1:
     dev: true
     engines:
@@ -5040,10 +5077,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
-  /graphql-compose/6.3.8_graphql@14.5.8:
+  /graphql-compose/6.3.8_graphql@14.6.0:
     dependencies:
-      graphql: 14.5.8
-      graphql-type-json: 0.2.4_graphql@14.5.8
+      graphql: 14.6.0
+      graphql-type-json: 0.2.4_graphql@14.6.0
       object-path: 0.11.4
     dev: true
     engines:
@@ -5052,10 +5089,10 @@ packages:
       graphql: '>=0.13.0 || >=14.0.0 || >=14.1.0'
     resolution:
       integrity: sha512-o0/jzQEMIpSjryLKwmD1vGrCubiPxD0LxlGTgWDSu38TBepu2GhugC9gYgTEbtiCZAHPtvkZ90SzzABOWZyQLA==
-  /graphql-config/2.2.1_graphql@14.5.8:
+  /graphql-config/2.2.1_graphql@14.6.0:
     dependencies:
-      graphql: 14.5.8
-      graphql-import: 0.7.1_graphql@14.5.8
+      graphql: 14.6.0
+      graphql-import: 0.7.1_graphql@14.6.0
       graphql-request: 1.8.2
       js-yaml: 3.13.1
       lodash: 4.17.15
@@ -5067,9 +5104,9 @@ packages:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0
     resolution:
       integrity: sha512-U8+1IAhw9m6WkZRRcyj8ZarK96R6lQBQ0an4lp76Ps9FyhOXENC5YQOxOFGm5CxPrX2rD0g3Je4zG5xdNJjwzQ==
-  /graphql-import/0.7.1_graphql@14.5.8:
+  /graphql-import/0.7.1_graphql@14.6.0:
     dependencies:
-      graphql: 14.5.8
+      graphql: 14.6.0
       lodash: 4.17.15
       resolve-from: 4.0.0
     dev: true
@@ -5098,22 +5135,22 @@ packages:
     dev: true
     resolution:
       integrity: sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
-  /graphql-type-json/0.2.4_graphql@14.5.8:
+  /graphql-type-json/0.2.4_graphql@14.6.0:
     dependencies:
-      graphql: 14.5.8
+      graphql: 14.6.0
     dev: true
     peerDependencies:
       graphql: '>=0.8.0'
     resolution:
       integrity: sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==
-  /graphql/14.5.8:
+  /graphql/14.6.0:
     dependencies:
       iterall: 1.3.0
     dev: true
     engines:
       node: '>= 6.x'
     resolution:
-      integrity: sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
+      integrity: sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
   /gud/1.0.0:
     dev: true
     resolution:
@@ -5140,7 +5177,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.7.5
+      uglify-js: 3.7.7
     resolution:
       integrity: sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==
   /has-ansi/2.0.0:
@@ -5254,16 +5291,23 @@ packages:
     dev: true
     resolution:
       integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
+  /hasha/5.1.0:
+    dependencies:
+      is-stream: 2.0.0
+      type-fest: 0.8.1
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==
   /hex-color-regex/1.1.0:
     dev: true
     resolution:
       integrity: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
-  /highlight.js/9.17.1:
-    dependencies:
-      handlebars: 4.7.2
+  /highlight.js/9.18.1:
     dev: true
     resolution:
-      integrity: sha512-TA2/doAur5Ol8+iM3Ov7qy3jYcr/QiJ2eDTdRF4dfbjG7AaaB99J5G+zSl11ljbl6cIcahgPY6SKb3sC3EJ0fw==
+      integrity: sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
   /hmac-drbg/1.0.1:
     dependencies:
       hash.js: 1.1.7
@@ -5272,12 +5316,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
-  /hoist-non-react-statics/3.3.1:
+  /hoist-non-react-statics/3.3.2:
     dependencies:
       react-is: 16.12.0
     dev: true
     resolution:
-      integrity: sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==
+      integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   /homedir-polyfill/1.0.3:
     dependencies:
       parse-passwd: 1.0.0
@@ -5399,7 +5443,7 @@ packages:
   /http-proxy/1.18.0:
     dependencies:
       eventemitter3: 4.0.0
-      follow-redirects: 1.9.0
+      follow-redirects: 1.10.0
       requires-port: 1.0.0
     dev: true
     engines:
@@ -5551,10 +5595,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-  /ink-spinner/3.0.1_ink@2.6.0+react@16.12.0:
+  /ink-spinner/3.0.1_ink@2.7.0+react@16.12.0:
     dependencies:
       cli-spinners: 1.3.1
-      ink: 2.6.0_react@16.12.0
+      ink: 2.7.0_react@16.12.0
       prop-types: 15.7.2
       react: 16.12.0
     dev: true
@@ -5566,17 +5610,17 @@ packages:
       react: ^16.8.2
     resolution:
       integrity: sha512-AVR4Z/NXDQ7dT5ltWcCzFS9Dd4T8eaO//E2UO8VYNiJcZpPCSJ11o5A0UVPcMlZxGbGD6ikUFDR3ZgPUQk5haQ==
-  /ink/2.6.0_react@16.12.0:
+  /ink/2.7.0_react@16.12.0:
     dependencies:
       ansi-escapes: 4.3.0
       arrify: 2.0.1
-      auto-bind: 3.0.0
+      auto-bind: 4.0.0
       chalk: 3.0.0
       cli-cursor: 3.1.0
       cli-truncate: 2.1.0
       is-ci: 2.0.0
       lodash.throttle: 4.1.1
-      log-update: 3.3.0
+      log-update: 3.4.0
       prop-types: 15.7.2
       react: 16.12.0
       react-reconciler: 0.24.0_react@16.12.0
@@ -5594,8 +5638,11 @@ packages:
     peerDependencies:
       '@types/react': '>=16.8.0'
       react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
     resolution:
-      integrity: sha512-nD/wlSuB6WnFsFB0nUcOJdy28YvvDer3eo+gezjvZqojGA4Rx5sQpacvN//Aai83DRgwrRTyKBl5aciOcfP3zQ==
+      integrity: sha512-O89Ie8Bp5N4kC2OGOAPb0EOo1IE42hBiFFV+Ir3e9iEc6tB6aGQYWNHBLdxJvyP2Q7cQQ74/aJ3QwsPpQrKLyQ==
   /inquirer/3.3.0:
     dependencies:
       ansi-escapes: 3.2.0
@@ -5615,7 +5662,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
-  /inquirer/7.0.3:
+  /inquirer/7.0.4:
     dependencies:
       ansi-escapes: 4.3.0
       chalk: 2.4.2
@@ -5634,7 +5681,7 @@ packages:
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==
+      integrity: sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==
   /internal-ip/4.3.0:
     dependencies:
       default-gateway: 4.2.0
@@ -5644,6 +5691,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==
+  /internal-slot/1.0.2:
+    dependencies:
+      es-abstract: 1.17.4
+      has: 1.0.3
+      side-channel: 1.0.2
+    dev: true
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==
   /interpret/1.2.0:
     dev: true
     engines:
@@ -6379,14 +6436,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
-  /levenary/1.1.0:
+  /levenary/1.1.1:
     dependencies:
       leven: 3.1.0
     dev: true
     engines:
-      node: '>= 8'
+      node: '>= 6'
     resolution:
-      integrity: sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==
+      integrity: sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
   /levn/0.3.0:
     dependencies:
       prelude-ls: 1.1.2
@@ -6469,6 +6526,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
+  /lodash.clonedeep/4.5.0:
+    dev: true
+    resolution:
+      integrity: sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
   /lodash.every/4.6.0:
     dev: true
     resolution:
@@ -6510,7 +6571,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-  /log-update/3.3.0:
+  /log-update/3.4.0:
     dependencies:
       ansi-escapes: 3.2.0
       cli-cursor: 2.1.0
@@ -6520,7 +6581,7 @@ packages:
       node: '>=6'
     optional: true
     resolution:
-      integrity: sha512-YSKm5n+YjZoGZT5lfmOqasVH1fIH9xQA9A81Y48nZ99PxAP62vdCCtua+Gcu6oTn0nqtZd/LwRV+Vflo53ZDWA==
+      integrity: sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==
   /loglevel/1.6.6:
     dev: true
     engines:
@@ -7071,12 +7132,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-VZR0zroAusy1ETZMZiGeLkdu50LGjG5U1KHZqTruqtTyQ2wfWhHG2Ow4nsUbfTFGlaREgNHcCWoM/OzEm6p+NQ==
-  /node-releases/1.1.45:
+  /node-releases/1.1.47:
     dependencies:
       semver: 6.3.0
     dev: true
     resolution:
-      integrity: sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==
+      integrity: sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==
   /noms/0.0.0:
     dependencies:
       inherits: 2.0.4
@@ -7087,7 +7148,7 @@ packages:
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.8.5
-      resolve: 1.14.2
+      resolve: 1.15.0
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
@@ -7269,7 +7330,7 @@ packages:
   /object.entries/1.1.1:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
       function-bind: 1.1.1
       has: 1.0.3
     dev: true
@@ -7280,7 +7341,7 @@ packages:
   /object.fromentries/2.0.2:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
       function-bind: 1.1.1
       has: 1.0.3
     dev: true
@@ -7291,7 +7352,7 @@ packages:
   /object.getownpropertydescriptors/2.1.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
     dev: true
     engines:
       node: '>= 0.8'
@@ -7308,7 +7369,7 @@ packages:
   /object.values/1.1.1:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
       function-bind: 1.1.1
       has: 1.0.3
     dev: true
@@ -7460,6 +7521,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
+  /p-defer/3.0.0:
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
   /p-finally/1.0.0:
     dev: true
     engines:
@@ -7561,7 +7628,7 @@ packages:
   /package-json/6.5.0:
     dependencies:
       got: 9.6.0
-      registry-auth-token: 4.1.0
+      registry-auth-token: 4.1.1
       registry-url: 5.1.0
       semver: 6.3.0
     dev: true
@@ -7569,10 +7636,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==
-  /pako/1.0.10:
+  /pako/1.0.11:
     dev: true
     resolution:
-      integrity: sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
+      integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
   /parallel-transform/1.2.0:
     dependencies:
       cyclist: 1.0.1
@@ -7833,7 +7900,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
-  /pnp-webpack-plugin/1.5.0_typescript@3.7.5:
+  /pnp-webpack-plugin/1.6.0_typescript@3.7.5:
     dependencies:
       ts-pnp: 1.1.5_typescript@3.7.5
     dev: true
@@ -7842,7 +7909,7 @@ packages:
     peerDependencies:
       typescript: '*'
     resolution:
-      integrity: sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==
+      integrity: sha512-ZcMGn/xF/fCOq+9kWMP9vVVxjIkMCja72oy3lziR7UHy0hHFZ57iVpQ71OtveVbmzeCmphBg8pxNdk/hlK99aQ==
   /portfinder/1.0.25:
     dependencies:
       async: 2.6.3
@@ -7870,7 +7937,7 @@ packages:
       integrity: sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==
   /postcss-colormin/4.0.3:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       color: 3.1.2
       has: 1.0.3
       postcss: 7.0.26
@@ -7960,12 +8027,12 @@ packages:
       integrity: sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==
   /postcss-merge-rules/4.0.3:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       caniuse-api: 3.0.0
       cssnano-util-same-parent: 4.0.1
       postcss: 7.0.26
       postcss-selector-parser: 3.1.1
-      vendors: 1.0.3
+      vendors: 1.0.4
     dev: true
     engines:
       node: '>=6.9.0'
@@ -7994,7 +8061,7 @@ packages:
   /postcss-minify-params/4.0.2:
     dependencies:
       alphanum-sort: 1.0.2
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       cssnano-util-get-arguments: 4.0.0
       postcss: 7.0.26
       postcss-value-parser: 3.3.1
@@ -8104,7 +8171,7 @@ packages:
       integrity: sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==
   /postcss-normalize-unicode/4.0.1:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       postcss: 7.0.26
       postcss-value-parser: 3.3.1
     dev: true
@@ -8144,7 +8211,7 @@ packages:
       integrity: sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==
   /postcss-reduce-initial/4.0.3:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       caniuse-api: 3.0.0
       has: 1.0.3
       postcss: 7.0.26
@@ -8507,11 +8574,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw==
-  /react-hot-loader/4.12.18:
+  /react-hot-loader/4.12.19:
     dependencies:
       fast-levenshtein: 2.0.6
       global: 4.4.0
-      hoist-non-react-statics: 3.3.1
+      hoist-non-react-statics: 3.3.2
       loader-utils: 1.2.3
       prop-types: 15.7.2
       react-lifecycles-compat: 3.0.4
@@ -8525,7 +8592,7 @@ packages:
       react: ^15.0.0 || ^16.0.0
       react-dom: ^15.0.0 || ^16.0.0
     resolution:
-      integrity: sha512-qYD0Qi9lIbg9jLyfmodfqvAQqCBsoPKxAhca8Nxvy2/2pO5Q9r2kM28jN0bbbSnhwK8dJ7FjsfVtXKOxMW+bqw==
+      integrity: sha512-p8AnA4QE2GtrvkdmqnKrEiijtVlqdTIDCHZOwItkI9kW51bt5XnQ/4Anz8giiWf9kqBpEQwsmnChDCAFBRyR/Q==
   /react-is/16.12.0:
     dev: true
     resolution:
@@ -8647,7 +8714,7 @@ packages:
       integrity: sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
   /rechoir/0.6.2:
     dependencies:
-      resolve: 1.14.2
+      resolve: 1.15.0
     dev: true
     engines:
       node: '>= 0.10'
@@ -8710,7 +8777,7 @@ packages:
   /regexp.prototype.flags/1.3.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
     dev: true
     engines:
       node: '>= 0.4'
@@ -8749,15 +8816,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
-  /registry-auth-token/4.1.0:
+  /registry-auth-token/4.1.1:
     dependencies:
       rc: 1.2.8
-      safe-buffer: 5.2.0
     dev: true
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-7uxS951DeOBOwsv8deX+l7HcjY2VZxaOgHtM6RKzg3HhpE+bJ0O7VbuMJLosC1T5WSFpHm0DuFIbqUl43jHpsA==
+      integrity: sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==
   /registry-url/5.1.0:
     dependencies:
       rc: 1.2.8
@@ -8865,12 +8931,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
-  /resolve/1.14.2:
+  /resolve/1.15.0:
     dependencies:
       path-parse: 1.0.6
     dev: true
     resolution:
-      integrity: sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
+      integrity: sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
   /responselike/1.0.2:
     dependencies:
       lowercase-keys: 1.0.0
@@ -8936,13 +9002,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  /rimraf/3.0.0:
+  /rimraf/3.0.1:
     dependencies:
       glob: 7.1.6
     dev: true
     hasBin: true
     resolution:
-      integrity: sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==
+      integrity: sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==
   /ripemd160/2.0.2:
     dependencies:
       hash-base: 3.0.4
@@ -9018,8 +9084,8 @@ packages:
       integrity: sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
   /schema-utils/0.4.7:
     dependencies:
-      ajv: 6.10.2
-      ajv-keywords: 3.4.1_ajv@6.10.2
+      ajv: 6.11.0
+      ajv-keywords: 3.4.1_ajv@6.11.0
     dev: true
     engines:
       node: '>= 4'
@@ -9027,9 +9093,9 @@ packages:
       integrity: sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
   /schema-utils/1.0.0:
     dependencies:
-      ajv: 6.10.2
-      ajv-errors: 1.0.1_ajv@6.10.2
-      ajv-keywords: 3.4.1_ajv@6.10.2
+      ajv: 6.11.0
+      ajv-errors: 1.0.1_ajv@6.11.0
+      ajv-keywords: 3.4.1_ajv@6.11.0
     dev: true
     engines:
       node: '>= 4'
@@ -9219,6 +9285,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  /side-channel/1.0.2:
+    dependencies:
+      es-abstract: 1.17.4
+      object-inspect: 1.7.0
+    dev: true
+    resolution:
+      integrity: sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==
   /sift/5.1.0:
     dev: true
     resolution:
@@ -9630,10 +9703,21 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  /string.prototype.matchall/4.0.2:
+    dependencies:
+      define-properties: 1.1.3
+      es-abstract: 1.17.4
+      has-symbols: 1.0.1
+      internal-slot: 1.0.2
+      regexp.prototype.flags: 1.3.0
+      side-channel: 1.0.2
+    dev: true
+    resolution:
+      integrity: sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==
   /string.prototype.padend/3.1.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
     dev: true
     engines:
       node: '>= 0.4'
@@ -9752,7 +9836,7 @@ packages:
       integrity: sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==
   /stylehacks/4.0.3:
     dependencies:
-      browserslist: 4.8.3
+      browserslist: 4.8.6
       postcss: 7.0.26
       postcss-selector-parser: 3.1.1
     dev: true
@@ -9819,7 +9903,7 @@ packages:
       integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
   /table/5.4.6:
     dependencies:
-      ajv: 6.10.2
+      ajv: 6.11.0
       lodash: 4.17.15
       slice-ansi: 2.1.0
       string-width: 3.1.0
@@ -9842,12 +9926,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
-  /term-size/2.1.1:
+  /term-size/2.2.0:
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A==
+      integrity: sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==
   /terser-webpack-plugin/1.4.3_webpack@4.41.5:
     dependencies:
       cacache: 12.0.3
@@ -10088,7 +10172,7 @@ packages:
       '@types/minimatch': 3.0.3
       fs-extra: 8.1.0
       handlebars: 4.7.2
-      highlight.js: 9.17.1
+      highlight.js: 9.18.1
       lodash: 4.17.15
       marked: 0.8.0
       minimatch: 3.0.4
@@ -10113,7 +10197,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
-  /uglify-js/3.7.5:
+  /uglify-js/3.7.7:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -10123,7 +10207,7 @@ packages:
     hasBin: true
     optional: true
     resolution:
-      integrity: sha512-GFZ3EXRptKGvb/C1Sq6nO1iI7AGcjyqmIyOw0DrD0675e+NNbGO72xmMM2iEBdFbxaTLo70NbjM/Wy54uZIlsg==
+      integrity: sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==
   /unc-path-regex/0.1.2:
     dev: true
     engines:
@@ -10322,7 +10406,7 @@ packages:
   /util.promisify/1.0.1:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.2
+      es-abstract: 1.17.4
       has-symbols: 1.0.1
       object.getownpropertydescriptors: 2.1.0
     dev: true
@@ -10381,10 +10465,10 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
-  /vendors/1.0.3:
+  /vendors/1.0.4:
     dev: true
     resolution:
-      integrity: sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==
+      integrity: sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==
   /vm-browserify/1.1.2:
     dev: true
     resolution:
@@ -10424,7 +10508,7 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==
-  /webpack-dev-server/3.10.1_webpack@4.41.5:
+  /webpack-dev-server/3.10.2_webpack@4.41.5:
     dependencies:
       ansi-html: 0.0.7
       bonjour: 3.5.0
@@ -10466,8 +10550,12 @@ packages:
     hasBin: true
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
     resolution:
-      integrity: sha512-AGG4+XrrXn4rbZUueyNrQgO4KGnol+0wm3MPdqGLmmA+NofZl3blZQKxZ9BND6RDNuvAK9OMYClhjOSnxpWRoA==
+      integrity: sha512-pxZKPYb+n77UN8u9YxXT4IaIrGcNtijh/mi8TXbErHmczw0DtPnMTTjHj+eNjkqLOaAZM/qD7V59j/qJsEiaZA==
   /webpack-hot-middleware/2.25.0:
     dependencies:
       ansi-html: 0.0.7
@@ -10512,8 +10600,8 @@ packages:
       '@webassemblyjs/wasm-edit': 1.8.5
       '@webassemblyjs/wasm-parser': 1.8.5
       acorn: 6.4.0
-      ajv: 6.10.2
-      ajv-keywords: 3.4.1_ajv@6.10.2
+      ajv: 6.11.0
+      ajv-keywords: 3.4.1_ajv@6.11.0
       chrome-trace-event: 1.0.2
       enhanced-resolve: 4.1.1
       eslint-scope: 4.0.3
@@ -10719,10 +10807,10 @@ packages:
       node: '>=0.4.0'
     resolution:
       integrity: sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
-  /xstate/4.7.6:
+  /xstate/4.7.8:
     dev: true
     resolution:
-      integrity: sha512-TjBk1/uOxu2yxSQW0eNNasOvKMtg+4KknlkM57Pw9D+jF124nLz+Qo4nEcC98rR6YMw4d9VxunIb5XzOjgLqlQ==
+      integrity: sha512-pRCBefTPvQRJWpvFi9xP4PkgozqpppKjC4xM1WjeFWxIroV1b7Jch4tnky30ZO4ywpVyn8bQMNRIC+5tuTfEKQ==
   /xtend/4.0.2:
     dev: true
     engines:
@@ -10749,7 +10837,7 @@ packages:
       integrity: sha512-p9QIzcFSNm4mCw/m5NdyMfN4RE4aFZJWRRb01ERVNGCym8VNbKtw3OYZXnvUIkim6U/EjqE/2yIh9F/msShH9A==
   /yaml/1.7.2:
     dependencies:
-      '@babel/runtime': 7.8.3
+      '@babel/runtime': 7.8.4
     dev: true
     engines:
       node: '>= 6'
@@ -10812,7 +10900,7 @@ packages:
     optional: true
     resolution:
       integrity: sha512-9SNQpwuEh2NucU83i2KMZnONVudZ86YNcFk9tq74YaqrQfgJWO3yB9uzH1tAg8iqh5c9F5j0wuyJ2z72wcum2w==
-  /yurnalist/1.1.1:
+  /yurnalist/1.1.2:
     dependencies:
       babel-runtime: 6.26.0
       chalk: 2.4.2
@@ -10820,7 +10908,7 @@ packages:
       debug: 4.1.1
       deep-equal: 1.1.1
       detect-indent: 6.0.0
-      inquirer: 7.0.3
+      inquirer: 7.0.4
       invariant: 2.2.4
       is-builtin-module: 3.0.0
       is-ci: 2.0.0
@@ -10829,7 +10917,7 @@ packages:
       node-emoji: 1.10.0
       object-path: 0.11.4
       read: 1.0.7
-      rimraf: 3.0.0
+      rimraf: 3.0.1
       semver: 6.3.0
       strip-ansi: 5.2.0
       strip-bom: 4.0.0
@@ -10837,16 +10925,17 @@ packages:
     engines:
       node: '>=4.0.0'
     resolution:
-      integrity: sha512-WMk8SL262zU/3Cr8twpfx/kdhPDAkhWN9HukNeb1U1xVrwU9iIAsCgYI8J5QMZTz+5N3Et/ZKzvOzVCjd/dAWA==
+      integrity: sha512-y7bsTXqL+YMJQ2De2CBtSftJNLQnB7gWIzzKm10GDyC8Fg4Dsmd2LG5YhT8pudvUiuotic80WVXt/g1femRVQg==
 specifiers:
-  '@jtechsvcs/eslint-config-typescript': ^2.0.1
-  '@types/node': ^12.6.9
-  '@typescript-eslint/eslint-plugin': ^2.16.0
-  '@typescript-eslint/parser': ^2.16.0
-  '@typescript-eslint/typescript-estree': ^2.16.0
+  '@jtechsvcs/eslint-config-typescript': ^2.0.3
+  '@types/node': ^12.12.26
+  '@types/webpack': ^4.41.5
+  '@typescript-eslint/eslint-plugin': ^2.19.0
+  '@typescript-eslint/parser': ^2.19.0
+  '@typescript-eslint/typescript-estree': ^2.19.0
   eslint: ^6.8.0
-  gatsby: ^2.13.50
+  gatsby: ^2.19.12
   npm-run-all: ^4.1.5
-  rimraf: ^3.0.0
-  typedoc: ^0.15.0
+  rimraf: ^3.0.1
+  typedoc: ^0.15.8
   typescript: ^3.7.5

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -4,7 +4,7 @@ import { GatsbyNode, CreateWebpackConfigArgs, PluginOptions } from 'gatsby';
 import { realpath, isDir, fileExists } from './utils';
 
 interface IPnpmOptions extends PluginOptions {
-    packages: string[];
+    resolutions: string[];
 }
 
 /**
@@ -18,7 +18,7 @@ interface IPnpmOptions extends PluginOptions {
  *
  * | Option    | Description |
  * |:----------|:------------|
- * | packages  |a list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.|
+ * | resolutions  |a list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.|
  */
 export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async ({ actions }: CreateWebpackConfigArgs, options: IPnpmOptions): Promise<void> => {
     const { setWebpackConfig } = actions;
@@ -32,8 +32,8 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async 
         pnpmNodeModules,
     ];
 
-    if (options.packages) {
-        for (const pkgName of options.packages) {
+    if (options.resolutions) {
+        for (const pkgName of options.resolutions) {
             // If the defined package name option is a directory, then resolve its realpath and
             // load it directly
             if (await isDir(pkgName)) {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -3,7 +3,7 @@ import { Configuration } from 'webpack';
 import { GatsbyNode, CreateWebpackConfigArgs, PluginOptions } from 'gatsby';
 import { realpath, isDir, fileExists, walkBack } from './utils';
 
-interface IPnpmOptions extends PluginOptions {
+interface IPluginOptions extends PluginOptions {
     include: string[];
 }
 
@@ -12,7 +12,7 @@ interface IPnpmOptions extends PluginOptions {
  * installed using `pnpm`
  * @param {CreateWebpackConfigArgs} config The configuration options that are passed in by
  * `gatsby`.
- * @param {IPnpmOptions} options The options provided by the user in `gatsby-config`.
+ * @param {IPluginOptions} options The options provided by the user in `gatsby-config`.
  *
  * Available options are:
  *
@@ -20,7 +20,7 @@ interface IPnpmOptions extends PluginOptions {
  * |:--------|:------------|
  * | include | a list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.|
  */
-export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async ({ actions, reporter }: CreateWebpackConfigArgs, options: IPnpmOptions): Promise<void> => {
+export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async ({ actions, reporter }: CreateWebpackConfigArgs, options: IPluginOptions): Promise<void> => {
     const { setWebpackConfig } = actions;
     const nodeModules = path.join(process.cwd(), 'node_modules');
     const pnpmNodeModules = path.join(nodeModules, '.pnpm', 'node_modules');

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -4,7 +4,7 @@ import { GatsbyNode, CreateWebpackConfigArgs, PluginOptions } from 'gatsby';
 import { realpath, isDir, fileExists, walkBack } from './utils';
 
 interface IPnpmOptions extends PluginOptions {
-    resolutions: string[];
+    include: string[];
 }
 
 /**
@@ -16,9 +16,9 @@ interface IPnpmOptions extends PluginOptions {
  *
  * Available options are:
  *
- * | Option    | Description |
- * |:----------|:------------|
- * | resolutions  |a list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.|
+ * | Option  | Description |
+ * |:--------|:------------|
+ * | include | a list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.|
  */
 export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async ({ actions, reporter }: CreateWebpackConfigArgs, options: IPnpmOptions): Promise<void> => {
     const { setWebpackConfig } = actions;
@@ -27,7 +27,7 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async 
     const gatsbyNodeModules = await walkBack(await realpath(path.join(nodeModules, 'gatsby')));
 
     if (!gatsbyNodeModules) {
-        throw new Error("[gatsby-plugin-pnpm] Unable to resolve your Gatsby install's real path!!");
+        return reporter.panic("[gatsby-plugin-pnpm] Unable to resolve your Gatsby install's real path!!");
     }
 
     const modulePaths: string[] = [
@@ -38,7 +38,7 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async 
     ];
 
     if (options.resolutions) {
-        for (const pkgName of options.resolutions) {
+        for (const pkgName of options.include) {
             // If the defined package name option is a directory, then resolve its realpath and
             // load it directly
             if (await isDir(pkgName)) {

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { Configuration } from 'webpack';
 import { GatsbyNode, CreateWebpackConfigArgs, PluginOptions } from 'gatsby';
-import { realpath, isDir, fileExists } from './utils';
+import { realpath, isDir, fileExists, walkBack } from './utils';
 
 interface IPnpmOptions extends PluginOptions {
     resolutions: string[];
@@ -20,15 +20,20 @@ interface IPnpmOptions extends PluginOptions {
  * |:----------|:------------|
  * | resolutions  |a list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.|
  */
-export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async ({ actions }: CreateWebpackConfigArgs, options: IPnpmOptions): Promise<void> => {
+export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async ({ actions, reporter }: CreateWebpackConfigArgs, options: IPnpmOptions): Promise<void> => {
     const { setWebpackConfig } = actions;
     const nodeModules = path.join(process.cwd(), 'node_modules');
     const pnpmNodeModules = path.join(nodeModules, '.pnpm', 'node_modules');
-    const gatsbyNodeModules = path.dirname(await realpath(path.join(nodeModules, 'gatsby')));
+    const gatsbyNodeModules = await walkBack(await realpath(path.join(nodeModules, 'gatsby')));
 
-    const modulePaths = [
-        gatsbyNodeModules,
+    if (!gatsbyNodeModules) {
+        throw new Error("[gatsby-plugin-pnpm] Unable to resolve your Gatsby install's real path!!");
+    }
+
+    const modulePaths: string[] = [
+        'node_modules',
         nodeModules,
+        gatsbyNodeModules,
         pnpmNodeModules,
     ];
 
@@ -41,11 +46,15 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async 
             } else {
                 // We need to check if the option is a valid dependency of the
                 // current project
-                const nodePath = path.resolve(path.join(nodeModules, pkgName));
+                const pkgPath = path.resolve(path.join(nodeModules, pkgName));
                 // If the resolved package name exists in the current project's
                 // node_modules, then push its realpath.
-                if (await fileExists(nodePath)) {
-                    modulePaths.push(await realpath(nodePath));
+                if (await fileExists(pkgPath)) {
+                    const nodePath = await walkBack(await realpath(pkgPath));
+                    if (nodePath) modulePaths.push(nodePath);
+                    if (!nodePath) {
+                        reporter.warn(`[gatsby-plugin-pnpm] Unable to locate dependency ${pkgName}'s node_modules from its real path`);
+                    }
                 }
             }
         }

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -1,23 +1,64 @@
-import { realpathSync } from 'fs';
-import { dirname, join } from 'path';
-import { GatsbyNode, CreateWebpackConfigArgs } from 'gatsby';
+import * as path from 'path';
+import { Configuration } from 'webpack';
+import { GatsbyNode, CreateWebpackConfigArgs, PluginOptions } from 'gatsby';
+import { realpath, isDir, fileExists } from './utils';
+
+interface IPnpmOptions extends PluginOptions {
+    packages: string[];
+}
 
 /**
  * Adds settings to the webpack configuration so that it will be able to resolve modules
  * installed using `pnpm`
  * @param {CreateWebpackConfigArgs} config The configuration options that are passed in by
  * `gatsby`.
+ * @param {IPnpmOptions} options The options provided by the user in `gatsby-config`.
+ *
+ * Available options are:
+ *
+ * | Option    | Description |
+ * |:----------|:------------|
+ * | packages  |a list of package names and/or paths that you would like to be made available to Webpack.  Each of these should either be the name of one of your project's direct dependencies, or a path to a folder containing packages that can be resolved as a module.|
  */
-export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = ({ actions }: CreateWebpackConfigArgs): void => {
-    const nodeModules = join(process.cwd(), 'node_modules');
-    const gatsbyNodeModules = dirname(realpathSync(join(nodeModules, 'gatsby')));
-    actions.setWebpackConfig({
-        resolve: {
-            modules: [
-                gatsbyNodeModules,
-                nodeModules,
-                'node_modules'
-            ]
+export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = async ({ actions }: CreateWebpackConfigArgs, options: IPnpmOptions): Promise<void> => {
+    const { setWebpackConfig } = actions;
+    const nodeModules = path.join(process.cwd(), 'node_modules');
+    const pnpmNodeModules = path.join(nodeModules, '.pnpm', 'node_modules');
+    const gatsbyNodeModules = path.dirname(await realpath(path.join(nodeModules, 'gatsby')));
+
+    const modulePaths = [
+        gatsbyNodeModules,
+        nodeModules,
+        pnpmNodeModules,
+    ];
+
+    if (options.packages) {
+        for (const pkgName of options.packages) {
+            // If the defined package name option is a directory, then resolve its realpath and
+            // load it directly
+            if (await isDir(pkgName)) {
+                modulePaths.push(await realpath(path.resolve(pkgName)));
+            } else {
+                // We need to check if the option is a valid dependency of the
+                // current project
+                const nodePath = path.resolve(path.join(nodeModules, pkgName));
+                // If the resolved package name exists in the current project's
+                // node_modules, then push its realpath.
+                if (await fileExists(nodePath)) {
+                    modulePaths.push(await realpath(nodePath));
+                }
+            }
         }
-    });
+    }
+
+    const config: Configuration = {
+        resolve: {
+            modules: modulePaths,
+        },
+        resolveLoader: {
+            modules: modulePaths,
+        },
+    };
+
+    setWebpackConfig(config);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,26 @@
+import { stat as _stat, Stats, realpath as _realpath } from 'fs';
+import { promisify } from 'util';
+
+const stat = promisify(_stat);
+export const realpath = promisify(_realpath);
+
+export const fileExists = async (filepath: string): Promise<Stats | void> => {
+    return new Promise((resolve, reject) => {
+        _stat(filepath, (err, fileStats) => {
+            if (err) {
+                return reject();
+            }
+            resolve(fileStats);
+        });
+    });
+};
+
+export const isDir = async (pathname: string): Promise<Boolean> => {
+    try {
+        const fsStat = await stat(pathname);
+        return fsStat.isDirectory();
+    } catch (err) {
+        //noop
+    }
+    return false;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { stat as _stat, Stats, realpath as _realpath } from 'fs';
 import { promisify } from 'util';
 
@@ -23,4 +24,15 @@ export const isDir = async (pathname: string): Promise<Boolean> => {
         //noop
     }
     return false;
+};
+
+export const walkBack = async (startPath: string): Promise<string | void> => {
+    let procPath = path.resolve(startPath);
+    let lastProcPath = '';
+    while (procPath.length > 0) {
+        if (path.basename(procPath) === 'node_modules' && await isDir(procPath)) return procPath;
+        procPath = path.resolve(procPath, '..');
+        if (procPath === lastProcPath) break; // Can't go back any further
+        lastProcPath = procPath;
+    }
 };


### PR DESCRIPTION
Adds the ability to define additional packages and/or directories to target for Webpack resolution.

The `include` plugin option:
1. Allows you to define package dependencies 
    * These must be direct dependencies of your project
2. Allows you to define **directories**
    * Directories that you define this way should follow the same general structure as `node_modules`.

Also extends the Webpack configuration to include the extended resolution paths in `resolveLoaders`, as well.

This PR also includes the "flat" pnpm `node_modules`, which has been a default feature since ~v4.7 (if I'm remembering correctly).  This is normally located at `node_modules/.pnpm/node_modules`.  Your packages dependencies, and sub-dependencies, are hoisted to this location, so it is useful as a catchall.

_**CAVEAT**_: the "flat" `node_modules` directory is subject to your hoisting options, so may not always be available, or may not include all of the packages you might expect.  In this case, when your modules are not being resolved, use the `include` option.

---

Fixes #1 