### PR TITLE
Update typescript to ^4.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ts-jest": "^25.2.0",
     "type-fest": "^0.10.0",
     "typedoc": "^0.15.8",
-    "typescript": "^3.7.5"
+    "typescript": "^4.6.3"
   },
   "dependencies": {
     "lodash.get": "^4.4.2",


### PR DESCRIPTION
Hoping this fixes the build for testing following https://stackoverflow.com/questions/72717949/error-in-node-modules-types-babel-traverse-index-d-ts68-50-error-ts1005

Will have a chance to check this properly locally soon but in case this is a quick solution...